### PR TITLE
feat(rl-agents): harden continuous PPO for robotics

### DIFF
--- a/examples/run_experiment.py
+++ b/examples/run_experiment.py
@@ -59,14 +59,23 @@ def main():
     print(f"✓ Metric whitelist: {whitelist}")
 
     metrics_db = Path("metrics.db")
-    backend = SQLiteBackend(metrics_db, batch_size=50)
+    metrics_experiment_id = 1
+    metrics_run_id = 1
+    metrics_execution_id = 1
+    backend = SQLiteBackend(
+        metrics_db,
+        experiment_id=metrics_experiment_id,
+        run_id=metrics_run_id,
+        execution_id=metrics_execution_id,
+        batch_size=50,
+    )
     configure(whitelist, backend=backend)
     print(f"✓ Metrics backend: {metrics_db}")
 
     # ── 3. Configure artifact store ───────────────────────────────────────────
     store = Store(experiment_id="dqn_cartpole_integration")
-    execution_id = uuid.uuid4()
-    print(f"✓ Store configured (execution_id={execution_id})")
+    artifact_execution_id = uuid.uuid4()
+    print(f"✓ Store configured (execution_id={artifact_execution_id})")
 
     # ── 4. Train ──────────────────────────────────────────────────────────────
     config = DQNConfig(
@@ -87,7 +96,7 @@ def main():
     # ── 5. Save checkpoint ────────────────────────────────────────────────────
     runner_state = result["runner_state"]
     final_params = runner_state[0].params
-    uri = store.put(final_params, name="final_weights", execution_id=execution_id)
+    uri = store.put(final_params, name="final_weights", execution_id=artifact_execution_id)
     print(f"✓ Checkpoint saved: {uri}")
 
     # Verify round-trip

--- a/libs/rl-agents/src/rl_agents/ppo.py
+++ b/libs/rl-agents/src/rl_agents/ppo.py
@@ -4,7 +4,7 @@ import jax
 import jax.numpy as jnp
 import optax
 from flax.training.train_state import TrainState
-from rl_components.networks import ActorCritic
+from rl_components.networks import ActorCritic, ContinuousActorCritic
 from rl_components.types import PPOConfig
 
 
@@ -26,6 +26,10 @@ class _ActionSpace(Protocol):
     n: int
 
 
+class _ContinuousActionSpace(Protocol):
+    shape: tuple[int, ...]
+
+
 class _EnvLike(Protocol):
     def observation_space(self, params: object | None = None) -> _ObservationSpace: ...
 
@@ -42,12 +46,36 @@ class _EnvLike(Protocol):
     ) -> tuple[jax.Array, object, jax.Array, jax.Array, dict[str, jax.Array]]: ...
 
 
+def _is_discrete_action_space(action_space: object) -> bool:
+    return hasattr(action_space, "n")
+
+
+def _continuous_action_dim(action_space: _ContinuousActionSpace) -> int:
+    if len(action_space.shape) != 1:
+        raise ValueError(f"continuous PPO expects a flat action shape, got {action_space.shape}")
+    return action_space.shape[0]
+
+
+def _sum_action_event_terms(values: object, *, is_continuous: bool) -> jax.Array:
+    values_array = jnp.asarray(values)
+    if not is_continuous:
+        return values_array
+    return jnp.sum(values_array, axis=-1)
+
+
 def make_train(config: PPOConfig, env: object, env_params: object | None = None):
     env = cast(_EnvLike, env)
 
     def train(rng):
         # INIT NETWORK
-        network = ActorCritic(env.action_space(env_params).n, activation="tanh")
+        action_space = env.action_space(env_params)
+        continuous_actions = not _is_discrete_action_space(action_space)
+        if continuous_actions:
+            continuous_action_space = cast(_ContinuousActionSpace, action_space)
+            network = ContinuousActorCritic(_continuous_action_dim(continuous_action_space), activation="tanh")
+        else:
+            discrete_action_space = cast(_ActionSpace, action_space)
+            network = ActorCritic(discrete_action_space.n, activation="tanh")
         rng, _rng = jax.random.split(rng)
         init_x = jnp.zeros(env.observation_space(env_params).shape)
         network_params = network.init(_rng, init_x)
@@ -76,9 +104,9 @@ def make_train(config: PPOConfig, env: object, env_params: object | None = None)
 
                 # SELECT ACTION
                 rng, _rng = jax.random.split(rng)
-                probs, value = network.apply(train_state.params, last_obs)
-                action = probs.sample(seed=_rng)
-                log_prob = jnp.asarray(probs.log_prob(action))
+                policy, value = network.apply(train_state.params, last_obs)
+                action = policy.sample(seed=_rng)
+                log_prob = _sum_action_event_terms(policy.log_prob(action), is_continuous=continuous_actions)
 
                 # STEP ENV
                 rng, _rng = jax.random.split(rng)
@@ -123,8 +151,8 @@ def make_train(config: PPOConfig, env: object, env_params: object | None = None)
 
                     def _loss_fn(params, traj_batch, advantages, targets):
                         # RERUN NETWORK
-                        probs, value = network.apply(params, traj_batch.obs)
-                        log_prob = probs.log_prob(traj_batch.action)
+                        policy, value = network.apply(params, traj_batch.obs)
+                        log_prob = _sum_action_event_terms(policy.log_prob(traj_batch.action), is_continuous=continuous_actions)
 
                         # CALCULATE VALUE LOSS
                         value_pred_clipped = traj_batch.value + (value - traj_batch.value).clip(-config.CLIP_EPS, config.CLIP_EPS)
@@ -147,7 +175,7 @@ def make_train(config: PPOConfig, env: object, env_params: object | None = None)
                         policy_loss = -jnp.minimum(loss_pc1, loss_pc2).mean()
 
                         # CALCULATE ENTROPY LOSS
-                        entropy_loss = probs.entropy().mean()
+                        entropy_loss = _sum_action_event_terms(policy.entropy(), is_continuous=continuous_actions).mean()
 
                         loss = policy_loss + config.VF_COEF * value_loss - config.ENT_COEF * entropy_loss
                         return loss, (value_loss, policy_loss, entropy_loss)

--- a/libs/rl-agents/src/rl_agents/ppo.py
+++ b/libs/rl-agents/src/rl_agents/ppo.py
@@ -1,3 +1,4 @@
+import math
 from typing import NamedTuple, Protocol, cast
 
 import jax
@@ -122,7 +123,11 @@ def _maybe_normalize_observation(
 
 def make_train(config: PPOConfig, env: object, env_params: object | None = None):
     env = cast(_EnvLike, env)
+    if not math.isfinite(config.REWARD_SCALE) or config.REWARD_SCALE <= 0.0:
+        raise ValueError(f"REWARD_SCALE must be finite and > 0, got {config.REWARD_SCALE!r}")
+
     normalize_observations = config.NORMALIZE_OBSERVATIONS
+    reward_scale = jnp.asarray(config.REWARD_SCALE, dtype=jnp.float32)
 
     def train(rng):
         # INIT NETWORK
@@ -177,8 +182,9 @@ def make_train(config: PPOConfig, env: object, env_params: object | None = None)
                 # STEP ENV
                 rng, _rng = jax.random.split(rng)
                 obsv, env_state, reward, done, info = env.step(_rng, env_state, action, env_params)
+                scaled_reward = reward * reward_scale
                 obs_norm_state = _maybe_update_observation_norm_state(obs_norm_state, obsv, enabled=normalize_observations)
-                transition = Transition(done, action, value, reward, log_prob, normalized_obs, info)
+                transition = Transition(done, action, value, scaled_reward, log_prob, normalized_obs, info)
                 runner_state = (train_state, env_state, obsv, obs_norm_state, rng)
                 return runner_state, transition
 

--- a/libs/rl-agents/src/rl_agents/ppo.py
+++ b/libs/rl-agents/src/rl_agents/ppo.py
@@ -18,6 +18,12 @@ class Transition(NamedTuple):
     info: dict[str, jax.Array]
 
 
+class _ObservationNormState(NamedTuple):
+    observation_count: jax.Array
+    mean: jax.Array
+    m2: jax.Array
+
+
 class _ObservationSpace(Protocol):
     shape: tuple[int, ...]
 
@@ -63,8 +69,60 @@ def _sum_action_event_terms(values: object, *, is_continuous: bool) -> jax.Array
     return jnp.sum(values_array, axis=-1)
 
 
+def _empty_observation_norm_state(obs: jax.Array) -> _ObservationNormState:
+    obs_array = jnp.asarray(obs, dtype=jnp.float32)
+    zeros = jnp.zeros_like(obs_array)
+    return _ObservationNormState(observation_count=jnp.array(0.0, dtype=jnp.float32), mean=zeros, m2=zeros)
+
+
+def _update_observation_norm_state(state: _ObservationNormState, obs: jax.Array) -> _ObservationNormState:
+    obs_array = jnp.asarray(obs, dtype=jnp.float32)
+    observation_count = state.observation_count + jnp.array(1.0, dtype=jnp.float32)
+    delta = obs_array - state.mean
+    mean = state.mean + delta / observation_count
+    delta2 = obs_array - mean
+    m2 = state.m2 + delta * delta2
+    return _ObservationNormState(observation_count=observation_count, mean=mean, m2=m2)
+
+
+def _init_observation_norm_state(obs: jax.Array) -> _ObservationNormState:
+    return _update_observation_norm_state(_empty_observation_norm_state(obs), obs)
+
+
+def _normalize_observation(state: _ObservationNormState, obs: jax.Array, *, eps: float, clip: float) -> jax.Array:
+    obs_array = jnp.asarray(obs, dtype=jnp.float32)
+    variance = jnp.where(
+        state.observation_count > 0.0,
+        state.m2 / state.observation_count,
+        jnp.ones_like(state.mean),
+    )
+    normalized_obs = (obs_array - state.mean) / jnp.sqrt(variance + jnp.asarray(eps, dtype=obs_array.dtype))
+    clip_value = jnp.asarray(clip, dtype=obs_array.dtype)
+    return jnp.clip(normalized_obs, -clip_value, clip_value)
+
+
+def _maybe_update_observation_norm_state(state: _ObservationNormState, obs: jax.Array, *, enabled: bool) -> _ObservationNormState:
+    if not enabled:
+        return state
+    return _update_observation_norm_state(state, obs)
+
+
+def _maybe_normalize_observation(
+    obs: jax.Array,
+    state: _ObservationNormState,
+    *,
+    eps: float,
+    clip: float,
+    enabled: bool,
+) -> jax.Array:
+    if not enabled:
+        return obs
+    return _normalize_observation(state, obs, eps=eps, clip=clip)
+
+
 def make_train(config: PPOConfig, env: object, env_params: object | None = None):
     env = cast(_EnvLike, env)
+    normalize_observations = config.NORMALIZE_OBSERVATIONS
 
     def train(rng):
         # INIT NETWORK
@@ -93,33 +151,49 @@ def make_train(config: PPOConfig, env: object, env_params: object | None = None)
         # INIT ENV
         rng, _rng = jax.random.split(rng)
         obsv, env_state = env.reset(_rng, env_params)
+        obs_norm_state = _init_observation_norm_state(obsv)
 
         # TRAIN LOOP
         def _update_step(runner_state, unused):
-            train_state, env_state, last_obs, rng = runner_state
+            train_state, env_state, last_obs, obs_norm_state, rng = runner_state
 
             # COLLECT TRAJECTORIES
             def _env_step(runner_state, unused):
-                train_state, env_state, last_obs, rng = runner_state
+                train_state, env_state, last_obs, obs_norm_state, rng = runner_state
+                normalized_obs = _maybe_normalize_observation(
+                    last_obs,
+                    obs_norm_state,
+                    eps=config.OBS_NORM_EPS,
+                    clip=config.OBS_NORM_CLIP,
+                    enabled=normalize_observations,
+                )
 
                 # SELECT ACTION
                 rng, _rng = jax.random.split(rng)
-                policy, value = network.apply(train_state.params, last_obs)
+                policy, value = network.apply(train_state.params, normalized_obs)
                 action = policy.sample(seed=_rng)
                 log_prob = _sum_action_event_terms(policy.log_prob(action), is_continuous=continuous_actions)
 
                 # STEP ENV
                 rng, _rng = jax.random.split(rng)
                 obsv, env_state, reward, done, info = env.step(_rng, env_state, action, env_params)
-                transition = Transition(done, action, value, reward, log_prob, last_obs, info)
-                runner_state = (train_state, env_state, obsv, rng)
+                obs_norm_state = _maybe_update_observation_norm_state(obs_norm_state, obsv, enabled=normalize_observations)
+                transition = Transition(done, action, value, reward, log_prob, normalized_obs, info)
+                runner_state = (train_state, env_state, obsv, obs_norm_state, rng)
                 return runner_state, transition
 
             runner_state, traj_batch = jax.lax.scan(_env_step, runner_state, None, config.NUM_STEPS)
 
             # CALCULATE ADVANTAGE
-            train_state, env_state, last_obs, rng = runner_state
-            _, last_val = network.apply(train_state.params, last_obs)
+            train_state, env_state, last_obs, obs_norm_state, rng = runner_state
+            normalized_last_obs = _maybe_normalize_observation(
+                last_obs,
+                obs_norm_state,
+                eps=config.OBS_NORM_EPS,
+                clip=config.OBS_NORM_CLIP,
+                enabled=normalize_observations,
+            )
+            _, last_val = network.apply(train_state.params, normalized_last_obs)
 
             def _calculate_gae(traj_batch, last_val):
                 def _get_advantages(gae_and_next_value, transition):
@@ -205,11 +279,11 @@ def make_train(config: PPOConfig, env: object, env_params: object | None = None)
             metric = jax.tree_util.tree_map(lambda x: x.mean(), traj_batch.info)
             metric["returned_episode_returns"] = traj_batch.info["returned_episode_returns"].mean()
 
-            runner_state = (train_state, env_state, last_obs, update_state[-1])
+            runner_state = (train_state, env_state, last_obs, obs_norm_state, update_state[-1])
             return runner_state, metric
 
         num_updates = config.TOTAL_TIMESTEPS // config.NUM_STEPS
-        runner_state = (train_state, env_state, obsv, rng)
+        runner_state = (train_state, env_state, obsv, obs_norm_state, rng)
         runner_state, metrics = jax.lax.scan(_update_step, runner_state, None, num_updates)
         return {"runner_state": runner_state, "metrics": metrics}
 

--- a/libs/rl-components/src/rl_components/networks.py
+++ b/libs/rl-components/src/rl_components/networks.py
@@ -1,9 +1,40 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import distrax
 import flax.linen as nn
 import jax
 import jax.numpy as jnp
+
+from rl_components.structs import chex_struct
+
+
+def _activation_fn(name: str):
+    if name == "relu":
+        return nn.relu
+    return nn.tanh
+
+
+@chex_struct(frozen=True)
+class TanhNormalDiag:
+    mean: jax.Array
+    log_std: jax.Array
+    epsilon: float = 1e-6
+
+    def _base_distribution(self) -> distrax.Normal:
+        return distrax.Normal(self.mean, jnp.exp(self.log_std))
+
+    def sample(self, seed: jax.Array) -> jax.Array:
+        raw_action = self._base_distribution().sample(seed=seed)
+        return cast(jax.Array, jnp.tanh(raw_action))
+
+    def log_prob(self, value: jax.Array) -> jax.Array:
+        clipped_value = jnp.clip(value, -1.0 + self.epsilon, 1.0 - self.epsilon)
+        pre_tanh_value = jnp.arctanh(clipped_value)
+        log_prob = self._base_distribution().log_prob(pre_tanh_value)
+        return cast(jax.Array, log_prob - jnp.log(1.0 - jnp.square(clipped_value) + self.epsilon))
+
+    def entropy(self) -> jax.Array:
+        return cast(jax.Array, self._base_distribution().entropy())
 
 
 class ActorCritic(nn.Module):
@@ -21,10 +52,7 @@ class ActorCritic(nn.Module):
 
     @nn.compact
     def __call__(self, x: jnp.ndarray) -> tuple[distrax.Categorical, jnp.ndarray]:
-        if self.activation == "relu":
-            activation = nn.relu
-        else:
-            activation = nn.tanh
+        activation = _activation_fn(self.activation)
 
         # Separate actor and critic paths for stability
         actor_x = nn.Dense(64, kernel_init=nn.initializers.orthogonal(jnp.sqrt(2)))(x)
@@ -41,3 +69,40 @@ class ActorCritic(nn.Module):
         critic_value = nn.Dense(1, kernel_init=nn.initializers.orthogonal(1.0))(critic_x)
 
         return probs, jnp.squeeze(critic_value, axis=-1)
+
+
+class ContinuousActorCritic(nn.Module):
+    action_dim: int
+    activation: str = "tanh"
+    log_std_min: float = -20.0
+    log_std_max: float = 2.0
+
+    if TYPE_CHECKING:
+        def apply(
+            self,
+            variables: object,
+            x: jax.Array,
+            *,
+            rngs: object | None = None,
+        ) -> tuple[TanhNormalDiag, jax.Array]: ...
+
+    @nn.compact
+    def __call__(self, x: jnp.ndarray) -> tuple[TanhNormalDiag, jnp.ndarray]:
+        activation = _activation_fn(self.activation)
+
+        actor_x = nn.Dense(64, kernel_init=nn.initializers.orthogonal(jnp.sqrt(2)))(x)
+        actor_x = activation(actor_x)
+        actor_x = nn.Dense(64, kernel_init=nn.initializers.orthogonal(jnp.sqrt(2)))(actor_x)
+        actor_x = activation(actor_x)
+        actor_mean = nn.Dense(self.action_dim, kernel_init=nn.initializers.orthogonal(0.01))(actor_x)
+        actor_log_std = self.param("log_std", nn.initializers.zeros, (self.action_dim,))
+        actor_log_std = jnp.clip(actor_log_std, self.log_std_min, self.log_std_max)
+        policy = TanhNormalDiag(mean=actor_mean, log_std=actor_log_std)
+
+        critic_x = nn.Dense(64, kernel_init=nn.initializers.orthogonal(jnp.sqrt(2)))(x)
+        critic_x = activation(critic_x)
+        critic_x = nn.Dense(64, kernel_init=nn.initializers.orthogonal(jnp.sqrt(2)))(critic_x)
+        critic_x = activation(critic_x)
+        critic_value = nn.Dense(1, kernel_init=nn.initializers.orthogonal(1.0))(critic_x)
+
+        return policy, jnp.squeeze(critic_value, axis=-1)

--- a/libs/rl-components/src/rl_components/types.py
+++ b/libs/rl-components/src/rl_components/types.py
@@ -17,6 +17,7 @@ class PPOConfig:
     ENT_COEF: float = 0.01
     VF_COEF: float = 0.5
     MAX_GRAD_NORM: float = 0.5
+    REWARD_SCALE: float = 1.0
     NORMALIZE_OBSERVATIONS: bool = False
     OBS_NORM_EPS: float = 1e-8
     OBS_NORM_CLIP: float = 10.0

--- a/libs/rl-components/src/rl_components/types.py
+++ b/libs/rl-components/src/rl_components/types.py
@@ -17,6 +17,9 @@ class PPOConfig:
     ENT_COEF: float = 0.01
     VF_COEF: float = 0.5
     MAX_GRAD_NORM: float = 0.5
+    NORMALIZE_OBSERVATIONS: bool = False
+    OBS_NORM_EPS: float = 1e-8
+    OBS_NORM_CLIP: float = 10.0
 
     # Environment
     ENV_NAME: str = "MountainCar-v0"

--- a/tests/medium/test_rl_agents_ppo_gradient.py
+++ b/tests/medium/test_rl_agents_ppo_gradient.py
@@ -7,8 +7,8 @@ import jax.numpy as jnp
 import optax
 import pytest
 from flax.training.train_state import TrainState
-from rl_agents.ppo import make_train
-from rl_components.networks import ActorCritic
+from rl_agents.ppo import _sum_action_event_terms, make_train
+from rl_components.networks import ActorCritic, ContinuousActorCritic
 from rl_components.types import PPOConfig
 
 
@@ -20,6 +20,11 @@ class FakeObservationSpace:
 @dataclass(frozen=True)
 class FakeActionSpace:
     n: int
+
+
+@dataclass(frozen=True)
+class FakeContinuousActionSpace:
+    shape: tuple[int, ...]
 
 
 class FakeDiscreteEnv:
@@ -52,6 +57,42 @@ class FakeDiscreteEnv:
             jnp.full((4,), next_state, dtype=jnp.float32),
             next_state,
             jnp.array(1.0, dtype=jnp.float32),
+            jnp.array(False),
+            info,
+        )
+
+
+class FakeContinuousEnv:
+    def observation_space(self, params: object | None = None) -> FakeObservationSpace:
+        del params
+        return FakeObservationSpace(shape=(4,))
+
+    def action_space(self, params: object | None = None) -> FakeContinuousActionSpace:
+        del params
+        return FakeContinuousActionSpace(shape=(2,))
+
+    def reset(self, key: jax.Array, params: object | None = None) -> tuple[jax.Array, jax.Array]:
+        del key, params
+        return jnp.zeros((4,), dtype=jnp.float32), jnp.array(0, dtype=jnp.int32)
+
+    def step(
+        self,
+        key: jax.Array,
+        state: jax.Array,
+        action: jax.Array,
+        params: object | None = None,
+    ) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array, dict[str, jax.Array]]:
+        del key, params
+        next_state = state + jnp.array(1, dtype=jnp.int32)
+        info = {
+            "returned_episode": jnp.array(False),
+            "returned_episode_returns": jnp.array(0.0, dtype=jnp.float32),
+        }
+        reward = jnp.array(1.0, dtype=jnp.float32) - 0.1 * jnp.sum(jnp.square(action))
+        return (
+            jnp.full((4,), next_state, dtype=jnp.float32),
+            next_state,
+            reward,
             jnp.array(False),
             info,
         )
@@ -143,6 +184,88 @@ class TestPPOGradientFlow:
             params,
             jnp.ones((8, 4)),
             jnp.zeros((8,), dtype=jnp.int32),
+            -jnp.ones((8,)) * 0.5,
+            jnp.ones((8,)),
+            jnp.ones((8,)),
+        )
+        assert loss.shape == ()
+
+
+class TestContinuousPPOGradientFlow:
+    def test_make_train_accepts_continuous_env(self) -> None:
+        config = PPOConfig(TOTAL_TIMESTEPS=4, NUM_STEPS=2, UPDATE_EPOCHS=1, NUM_MINIBATCHES=1)
+        train = make_train(config, env=FakeContinuousEnv(), env_params=None)
+
+        out = jax.jit(train)(jax.random.key(0))
+        metrics = out["metrics"]
+
+        assert metrics["returned_episode"].shape == (2,)
+        assert metrics["returned_episode_returns"].shape == (2,)
+
+    def test_params_change_after_update(self):
+        net = ContinuousActorCritic(action_dim=2)
+        key = jax.random.key(0)
+        params = net.init(key, jnp.zeros((4,)))
+
+        cfg = PPOConfig(CLIP_EPS=0.2, VF_COEF=0.5, ENT_COEF=0.01, MAX_GRAD_NORM=0.5)
+        tx = optax.chain(optax.clip_by_global_norm(cfg.MAX_GRAD_NORM), optax.adam(cfg.LR, eps=1e-5))
+        train_state = TrainState.create(apply_fn=net.apply, params=params, tx=tx)
+
+        batch_size = 16
+        obs = jax.random.normal(jax.random.key(1), (batch_size, 4))
+        policy, _ = net.apply(train_state.params, obs)
+        actions = policy.sample(seed=jax.random.key(2))
+        old_log_probs = _sum_action_event_terms(policy.log_prob(actions), is_continuous=True)
+        advantages = jax.random.normal(jax.random.key(3), (batch_size,))
+        targets = jax.random.normal(jax.random.key(4), (batch_size,))
+
+        def loss_fn(params):
+            policy, value = net.apply(params, obs)
+            log_prob = _sum_action_event_terms(policy.log_prob(actions), is_continuous=True)
+
+            value_loss = 0.5 * jnp.mean(jnp.square(value - targets))
+
+            ratio = jnp.exp(log_prob - old_log_probs)
+            gae = (advantages - advantages.mean()) / (advantages.std() + 1e-8)
+            loss1 = ratio * gae
+            loss2 = jnp.clip(ratio, 1.0 - cfg.CLIP_EPS, 1.0 + cfg.CLIP_EPS) * gae
+            policy_loss = -jnp.minimum(loss1, loss2).mean()
+
+            entropy_loss = _sum_action_event_terms(policy.entropy(), is_continuous=True).mean()
+
+            return policy_loss + cfg.VF_COEF * value_loss - cfg.ENT_COEF * entropy_loss
+
+        grad_fn = jax.value_and_grad(loss_fn)
+        loss, grads = grad_fn(train_state.params)
+        new_state = train_state.apply_gradients(grads=grads)
+
+        old_flat = jax.tree_util.tree_leaves(train_state.params)
+        new_flat = jax.tree_util.tree_leaves(new_state.params)
+        any_changed = any(not jnp.allclose(o, n) for o, n in zip(old_flat, new_flat, strict=True))
+        assert loss.shape == ()
+        assert any_changed, "Parameters did not change after continuous PPO gradient step"
+
+    def test_continuous_ppo_loss_jit(self):
+        net = ContinuousActorCritic(action_dim=2)
+        params = net.init(jax.random.key(0), jnp.zeros((4,)))
+
+        @jax.jit
+        def compute_loss(params, obs, actions, old_log_probs, advantages, targets):
+            policy, value = net.apply(params, obs)
+            log_prob = _sum_action_event_terms(policy.log_prob(actions), is_continuous=True)
+            ratio = jnp.exp(log_prob - old_log_probs)
+            gae = (advantages - advantages.mean()) / (advantages.std() + 1e-8)
+            loss1 = ratio * gae
+            loss2 = jnp.clip(ratio, 0.8, 1.2) * gae
+            policy_loss = -jnp.minimum(loss1, loss2).mean()
+            value_loss = 0.5 * jnp.mean(jnp.square(value - targets))
+            entropy_loss = _sum_action_event_terms(policy.entropy(), is_continuous=True).mean()
+            return policy_loss + 0.5 * value_loss - 0.01 * entropy_loss
+
+        loss = compute_loss(
+            params,
+            jnp.ones((8, 4)),
+            jnp.zeros((8, 2), dtype=jnp.float32),
             -jnp.ones((8,)) * 0.5,
             jnp.ones((8,)),
             jnp.ones((8,)),

--- a/tests/medium/test_rl_agents_ppo_gradient.py
+++ b/tests/medium/test_rl_agents_ppo_gradient.py
@@ -98,6 +98,56 @@ class FakeContinuousEnv:
         )
 
 
+class LargeMagnitudeDiscreteEnv(FakeDiscreteEnv):
+    def reset(self, key: jax.Array, params: object | None = None) -> tuple[jax.Array, jax.Array]:
+        del key, params
+        return jnp.full((4,), 1e6, dtype=jnp.float32), jnp.array(0, dtype=jnp.int32)
+
+    def step(
+        self,
+        key: jax.Array,
+        state: jax.Array,
+        action: jax.Array,
+        params: object | None = None,
+    ) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array, dict[str, jax.Array]]:
+        del key, action, params
+        next_state = state + jnp.array(1, dtype=jnp.int32)
+        info = {
+            "returned_episode": jnp.array(False),
+            "returned_episode_returns": jnp.array(0.0, dtype=jnp.float32),
+        }
+        scaled_obs = jnp.full((4,), 1e6 * (next_state + 1), dtype=jnp.float32)
+        return scaled_obs, next_state, jnp.array(1.0, dtype=jnp.float32), jnp.array(False), info
+
+
+class LargeMagnitudeContinuousEnv(FakeContinuousEnv):
+    def reset(self, key: jax.Array, params: object | None = None) -> tuple[jax.Array, jax.Array]:
+        del key, params
+        return jnp.full((4,), -1e6, dtype=jnp.float32), jnp.array(0, dtype=jnp.int32)
+
+    def step(
+        self,
+        key: jax.Array,
+        state: jax.Array,
+        action: jax.Array,
+        params: object | None = None,
+    ) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array, dict[str, jax.Array]]:
+        del key, params
+        next_state = state + jnp.array(1, dtype=jnp.int32)
+        info = {
+            "returned_episode": jnp.array(False),
+            "returned_episode_returns": jnp.array(0.0, dtype=jnp.float32),
+        }
+        reward = jnp.array(1.0, dtype=jnp.float32) - 0.1 * jnp.sum(jnp.square(action))
+        scaled_obs = jnp.full((4,), -1e6 * (next_state + 1), dtype=jnp.float32)
+        return scaled_obs, next_state, reward, jnp.array(False), info
+
+
+def _tree_all_finite(tree: object) -> bool:
+    leaves = jax.tree_util.tree_leaves(tree)
+    return all(bool(jnp.all(jnp.isfinite(leaf))) for leaf in leaves)
+
+
 class TestPPOGradientFlow:
     def test_make_train_accepts_injected_env(self) -> None:
         config = PPOConfig(TOTAL_TIMESTEPS=4, NUM_STEPS=2, UPDATE_EPOCHS=1, NUM_MINIBATCHES=1)
@@ -190,6 +240,23 @@ class TestPPOGradientFlow:
         )
         assert loss.shape == ()
 
+    def test_large_magnitude_observations_remain_finite_with_normalization(self) -> None:
+        config = PPOConfig(
+            TOTAL_TIMESTEPS=4,
+            NUM_STEPS=2,
+            UPDATE_EPOCHS=1,
+            NUM_MINIBATCHES=1,
+            NORMALIZE_OBSERVATIONS=True,
+        )
+        train = make_train(config, env=LargeMagnitudeDiscreteEnv(), env_params=None)
+
+        out = jax.jit(train)(jax.random.key(0))
+        final_train_state = out["runner_state"][0]
+        obs_norm_state = out["runner_state"][3]
+
+        assert _tree_all_finite(final_train_state.params)
+        assert jnp.allclose(obs_norm_state.observation_count, jnp.array(5.0, dtype=jnp.float32))
+
 
 class TestContinuousPPOGradientFlow:
     def test_make_train_accepts_continuous_env(self) -> None:
@@ -271,3 +338,20 @@ class TestContinuousPPOGradientFlow:
             jnp.ones((8,)),
         )
         assert loss.shape == ()
+
+    def test_large_magnitude_observations_remain_finite_with_normalization(self) -> None:
+        config = PPOConfig(
+            TOTAL_TIMESTEPS=4,
+            NUM_STEPS=2,
+            UPDATE_EPOCHS=1,
+            NUM_MINIBATCHES=1,
+            NORMALIZE_OBSERVATIONS=True,
+        )
+        train = make_train(config, env=LargeMagnitudeContinuousEnv(), env_params=None)
+
+        out = jax.jit(train)(jax.random.key(0))
+        final_train_state = out["runner_state"][0]
+        obs_norm_state = out["runner_state"][3]
+
+        assert _tree_all_finite(final_train_state.params)
+        assert jnp.allclose(obs_norm_state.observation_count, jnp.array(5.0, dtype=jnp.float32))

--- a/tests/medium/test_rl_agents_ppo_gradient.py
+++ b/tests/medium/test_rl_agents_ppo_gradient.py
@@ -143,6 +143,24 @@ class LargeMagnitudeContinuousEnv(FakeContinuousEnv):
         return scaled_obs, next_state, reward, jnp.array(False), info
 
 
+class RewardLoggingEnv(FakeDiscreteEnv):
+    def step(
+        self,
+        key: jax.Array,
+        state: jax.Array,
+        action: jax.Array,
+        params: object | None = None,
+    ) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array, dict[str, jax.Array]]:
+        del key, action, params
+        next_state = state + jnp.array(1, dtype=jnp.int32)
+        raw_reward = jnp.array(2.0, dtype=jnp.float32)
+        info = {
+            "returned_episode": jnp.array(True),
+            "returned_episode_returns": jnp.array(3.0, dtype=jnp.float32),
+        }
+        return jnp.full((4,), next_state, dtype=jnp.float32), next_state, raw_reward, jnp.array(False), info
+
+
 def _tree_all_finite(tree: object) -> bool:
     leaves = jax.tree_util.tree_leaves(tree)
     return all(bool(jnp.all(jnp.isfinite(leaf))) for leaf in leaves)
@@ -256,6 +274,49 @@ class TestPPOGradientFlow:
 
         assert _tree_all_finite(final_train_state.params)
         assert jnp.allclose(obs_norm_state.observation_count, jnp.array(5.0, dtype=jnp.float32))
+
+    def test_reward_scale_keeps_logged_returns_raw(self) -> None:
+        config = PPOConfig(
+            TOTAL_TIMESTEPS=4,
+            NUM_STEPS=2,
+            UPDATE_EPOCHS=1,
+            NUM_MINIBATCHES=1,
+            REWARD_SCALE=5.0,
+        )
+        train = make_train(config, env=RewardLoggingEnv(), env_params=None)
+
+        out = jax.jit(train)(jax.random.key(0))
+        returns = out["metrics"]["returned_episode_returns"]
+
+        assert jnp.allclose(returns, jnp.full((2,), 3.0, dtype=jnp.float32))
+
+    def test_reward_scale_changes_training_update(self) -> None:
+        unit_scale_train = make_train(
+            PPOConfig(TOTAL_TIMESTEPS=4, NUM_STEPS=2, UPDATE_EPOCHS=1, NUM_MINIBATCHES=1, REWARD_SCALE=1.0),
+            env=FakeDiscreteEnv(),
+            env_params=None,
+        )
+        amplified_scale_train = make_train(
+            PPOConfig(TOTAL_TIMESTEPS=4, NUM_STEPS=2, UPDATE_EPOCHS=1, NUM_MINIBATCHES=1, REWARD_SCALE=2.0),
+            env=FakeDiscreteEnv(),
+            env_params=None,
+        )
+
+        unit_scale_out = jax.jit(unit_scale_train)(jax.random.key(0))
+        amplified_scale_out = jax.jit(amplified_scale_train)(jax.random.key(0))
+
+        unit_params = unit_scale_out["runner_state"][0].params
+        amplified_params = amplified_scale_out["runner_state"][0].params
+        any_changed = any(
+            not jnp.allclose(unit_leaf, amplified_leaf)
+            for unit_leaf, amplified_leaf in zip(
+                jax.tree_util.tree_leaves(unit_params),
+                jax.tree_util.tree_leaves(amplified_params),
+                strict=True,
+            )
+        )
+
+        assert any_changed, "Reward scaling should alter PPO parameter updates"
 
 
 class TestContinuousPPOGradientFlow:

--- a/tests/medium/test_rl_components_networks.py
+++ b/tests/medium/test_rl_components_networks.py
@@ -2,7 +2,7 @@
 
 import jax
 import jax.numpy as jnp
-from rl_components.networks import ActorCritic
+from rl_components.networks import ActorCritic, ContinuousActorCritic
 
 
 class TestActorCriticForward:
@@ -56,3 +56,37 @@ class TestActorCriticForward:
         params = net.init(key, jnp.zeros((4,)))
         _, value = net.apply(params, jnp.ones((10, 4)))
         assert value.shape == (10,)
+
+
+class TestContinuousActorCriticForward:
+    def test_output_shapes_and_action_bounds(self):
+        net = ContinuousActorCritic(action_dim=3)
+        key = jax.random.key(0)
+        params = net.init(key, jnp.zeros((8,)))
+        policy, value = net.apply(params, jnp.ones((8,)))
+        action = policy.sample(seed=jax.random.key(1))
+        log_prob = jnp.sum(policy.log_prob(action), axis=-1)
+        entropy = jnp.sum(policy.entropy(), axis=-1)
+
+        assert policy.mean.shape == (3,)
+        assert action.shape == (3,)
+        assert jnp.all(action >= -1.0)
+        assert jnp.all(action <= 1.0)
+        assert log_prob.shape == ()
+        assert entropy.shape == ()
+        assert value.shape == ()
+
+    def test_batch_output_shapes_reduce_per_sample(self):
+        net = ContinuousActorCritic(action_dim=2)
+        key = jax.random.key(0)
+        params = net.init(key, jnp.zeros((4,)))
+        policy, value = net.apply(params, jnp.ones((5, 4)))
+        action = policy.sample(seed=jax.random.key(1))
+        log_prob = jnp.sum(policy.log_prob(action), axis=-1)
+        entropy = jnp.sum(policy.entropy(), axis=-1)
+
+        assert policy.mean.shape == (5, 2)
+        assert action.shape == (5, 2)
+        assert log_prob.shape == (5,)
+        assert entropy.shape == (5,)
+        assert value.shape == (5,)

--- a/tests/regression/test_ppo_learning.py
+++ b/tests/regression/test_ppo_learning.py
@@ -4,7 +4,7 @@ import jax
 from rl_agents.ppo import make_train
 from rl_components.types import PPOConfig
 
-_config = PPOConfig(TOTAL_TIMESTEPS=80_000, ENV_NAME="CartPole-v1")
+_config = PPOConfig(TOTAL_TIMESTEPS=80_000, ENV_NAME="CartPole-v1", NORMALIZE_OBSERVATIONS=True)
 
 
 def test_ppo_cartpole_learns():

--- a/tests/small/test_rl_agents_ppo.py
+++ b/tests/small/test_rl_agents_ppo.py
@@ -2,7 +2,7 @@
 
 
 import jax.numpy as jnp
-from rl_agents.ppo import Transition
+from rl_agents.ppo import Transition, _sum_action_event_terms
 
 
 class TestTransition:
@@ -79,3 +79,19 @@ class TestGAEComputation:
         delta = reward + gamma * next_value * not_done - value
         # done=1 → not_done=0 → next_value ignored
         assert abs(delta - (1.0 - 0.5)) < 1e-6
+
+
+class TestContinuousActionReductions:
+    def test_continuous_terms_reduce_last_axis(self):
+        terms = jnp.array([[0.1, 0.2], [0.3, 0.4]], dtype=jnp.float32)
+
+        reduced = _sum_action_event_terms(terms, is_continuous=True)
+
+        assert jnp.allclose(reduced, jnp.array([0.3, 0.7], dtype=jnp.float32))
+
+    def test_discrete_terms_remain_unchanged(self):
+        terms = jnp.array([0.1, 0.2], dtype=jnp.float32)
+
+        reduced = _sum_action_event_terms(terms, is_continuous=False)
+
+        assert jnp.array_equal(reduced, terms)

--- a/tests/small/test_rl_agents_ppo.py
+++ b/tests/small/test_rl_agents_ppo.py
@@ -2,13 +2,16 @@
 
 
 import jax.numpy as jnp
+import pytest
 from rl_agents.ppo import (
     Transition,
     _init_observation_norm_state,
     _normalize_observation,
     _sum_action_event_terms,
     _update_observation_norm_state,
+    make_train,
 )
+from rl_components.types import PPOConfig
 
 
 class TestTransition:
@@ -24,6 +27,37 @@ class TestTransition:
         )
         assert isinstance(t, tuple)
         assert t[3] == 1.0
+
+
+class _ValidationEnv:
+    def observation_space(self, params: object | None = None):
+        del params
+        return type("ObsSpace", (), {"shape": (4,)})()
+
+    def action_space(self, params: object | None = None):
+        del params
+        return type("ActionSpace", (), {"n": 2})()
+
+    def reset(self, key, params: object | None = None):
+        del key, params
+        return jnp.zeros((4,), dtype=jnp.float32), jnp.array(0, dtype=jnp.int32)
+
+    def step(self, key, state, action, params: object | None = None):
+        del key, state, action, params
+        info = {
+            "returned_episode": jnp.array(False),
+            "returned_episode_returns": jnp.array(0.0, dtype=jnp.float32),
+        }
+        return jnp.zeros((4,), dtype=jnp.float32), jnp.array(0, dtype=jnp.int32), jnp.array(1.0), jnp.array(False), info
+
+
+class TestRewardScaleValidation:
+    @pytest.mark.parametrize("reward_scale", [0.0, -1.0, float("inf"), float("nan")])
+    def test_make_train_rejects_non_positive_or_non_finite_reward_scale(self, reward_scale: float):
+        config = PPOConfig(REWARD_SCALE=reward_scale)
+
+        with pytest.raises(ValueError, match="REWARD_SCALE"):
+            make_train(config, env=_ValidationEnv(), env_params=None)
 
 
 class TestPPOClippedObjective:

--- a/tests/small/test_rl_agents_ppo.py
+++ b/tests/small/test_rl_agents_ppo.py
@@ -2,7 +2,13 @@
 
 
 import jax.numpy as jnp
-from rl_agents.ppo import Transition, _sum_action_event_terms
+from rl_agents.ppo import (
+    Transition,
+    _init_observation_norm_state,
+    _normalize_observation,
+    _sum_action_event_terms,
+    _update_observation_norm_state,
+)
 
 
 class TestTransition:
@@ -17,7 +23,7 @@ class TestTransition:
             info={},
         )
         assert isinstance(t, tuple)
-        assert t.reward == 1.0
+        assert t[3] == 1.0
 
 
 class TestPPOClippedObjective:
@@ -95,3 +101,30 @@ class TestContinuousActionReductions:
         reduced = _sum_action_event_terms(terms, is_continuous=False)
 
         assert jnp.array_equal(reduced, terms)
+
+
+class TestObservationNormalization:
+    def test_running_stats_track_mean_and_m2(self):
+        state = _init_observation_norm_state(jnp.array([2.0, 4.0], dtype=jnp.float32))
+
+        state = _update_observation_norm_state(state, jnp.array([4.0, 8.0], dtype=jnp.float32))
+
+        assert jnp.allclose(state.observation_count, jnp.array(2.0, dtype=jnp.float32))
+        assert jnp.allclose(state.mean, jnp.array([3.0, 6.0], dtype=jnp.float32))
+        assert jnp.allclose(state.m2, jnp.array([2.0, 8.0], dtype=jnp.float32))
+
+    def test_normalization_handles_zero_variance_without_nan(self):
+        obs = jnp.array([5.0, -5.0], dtype=jnp.float32)
+        state = _init_observation_norm_state(obs)
+
+        normalized = _normalize_observation(state, obs, eps=1e-8, clip=10.0)
+
+        assert jnp.all(jnp.isfinite(normalized))
+        assert jnp.allclose(normalized, jnp.zeros_like(obs))
+
+    def test_normalization_clips_large_values(self):
+        state = _init_observation_norm_state(jnp.array([0.0], dtype=jnp.float32))
+
+        normalized = _normalize_observation(state, jnp.array([100.0], dtype=jnp.float32), eps=1e-8, clip=3.0)
+
+        assert jnp.allclose(normalized, jnp.array([3.0], dtype=jnp.float32))

--- a/tests/small/test_rl_components_types.py
+++ b/tests/small/test_rl_components_types.py
@@ -11,6 +11,7 @@ class TestPPOConfig:
         assert cfg.GAMMA == 0.99
         assert cfg.GAE_LAMBDA == 0.95
         assert cfg.CLIP_EPS == 0.2
+        assert cfg.REWARD_SCALE == 1.0
         assert cfg.ENV_NAME == "MountainCar-v0"
 
     def test_frozen(self):
@@ -22,9 +23,10 @@ class TestPPOConfig:
             pass
 
     def test_custom_values(self):
-        cfg = PPOConfig(LR=1e-3, GAMMA=0.95, ENV_NAME="CartPole-v1")
+        cfg = PPOConfig(LR=1e-3, GAMMA=0.95, ENV_NAME="CartPole-v1", REWARD_SCALE=2.5)
         assert cfg.LR == 1e-3
         assert cfg.GAMMA == 0.95
+        assert cfg.REWARD_SCALE == 2.5
         assert cfg.ENV_NAME == "CartPole-v1"
 
     def test_num_updates_computation(self):


### PR DESCRIPTION
## Summary
- add a continuous PPO policy path with tanh-squashed Gaussian actions for normalized continuous action spaces
- add PPO-local observation normalization and reward scaling without changing raw logged returns
- extend PPO network, gradient, regression, and config coverage for the new continuous and stabilization paths

## Testing
- PYTHONPATH=libs/rl-components/src:libs/rl-agents/src uv run --with pytest pytest -q tests/small/test_rl_components_types.py tests/small/test_rl_agents_ppo.py tests/medium/test_rl_components_networks.py tests/medium/test_rl_agents_ppo_gradient.py tests/regression/test_ppo_learning.py
