### PR TITLE
chore: migrate type-checker from ty to pyrefly

### DIFF
--- a/.github/skills/contribute-to-upstream/references/contribute-to-upstream.md
+++ b/.github/skills/contribute-to-upstream/references/contribute-to-upstream.md
@@ -35,7 +35,7 @@ So the current upstream path is manual after the reusable change is in this repo
    - `CONTRIBUTING.md` says to keep PRs focused.
    - For harvested code, prefer one harvested library per PR.
 3. Run the relevant repo checks.
-   - `CONTRIBUTING.md` currently calls out `uv sync`, `uv run ty check .`, and `uv run ruff check .`.
+   - `CONTRIBUTING.md` currently calls out `uv sync`, `uv run pyrefly check`, and `uv run ruff check .`.
    - This repository’s active agent instructions and CI now treat `pyright` as the authoritative type-check gate, so use the repo’s current verification expectations for the touched surface.
 4. Commit with a conventional commit message.
 5. Push the branch.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,21 +45,7 @@ jobs:
         with:
           version: "latest"
       - run: uv sync --frozen
-      - run: |
-          cd cli && uv run pyright src
-          cd ../libs/experiment-definition && uv run pyright src
-          cd ../jax-eval && uv run pyright
-          cd ../jax-nn && uv run pyright src
-          cd ../jax-replay && uv run pyright src
-          cd ../jax-utils && uv run pyright src
-          cd ../research-analysis && uv run pyright src
-          cd ../research-cluster && uv run pyright src
-          cd ../research-instrument && uv run pyright src
-          cd ../research-plot && uv run pyright src
-          cd ../research-store && uv run pyright src
-          cd ../rl-components && uv run pyright src
-          cd ../rl-agents && uv run pyright src
-          cd ../.. && uv run pyright tests examples scripts
+      - run: uv run pyrefly check
 
   test-small:
     needs: [warm-uv-cache]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ We prioritize reproducibility, high performance, and code reuse.
 We use `uv` for dependency management.
 ```bash
 uv sync
-uv run ty check .
+uv run pyrefly check
 uv run ruff check .
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,7 +33,7 @@ Optimizing for high-performance computing.
 
 ## Technical Debt & Maintenance
 - [x] Continuous integration (CI) for all libraries using `uv run pytest`.
-- [ ] Enforce 100% type coverage via `ty check` in all `libs/`.
+- [ ] Enforce 100% type coverage via `pyrefly check` in all `libs/`.
 - [ ] Performance regression suite using `pytest-benchmark`.
 - [x] Add `research-instrument` SQLite persistent storage backend.
 - [x] Add rl-components test coverage (buffer, networks, types).

--- a/cli/src/research_cli/lifecycle.py
+++ b/cli/src/research_cli/lifecycle.py
@@ -324,8 +324,8 @@ def _ensure_root_workspace_library_registration(workspace_root: Path, library_na
         updated_sections.append("project.dependencies")
     if _ensure_toml_table_entry(lines, "[tool.uv.sources]", library_name, "{ workspace = true }"):
         updated_sections.append("tool.uv.sources")
-    if _ensure_toml_array_entry(lines, "[tool.ty.environment]", "extra-paths", f"libs/{library_name}/src"):
-        updated_sections.append("tool.ty.environment.extra-paths")
+    if _ensure_toml_array_entry(lines, "[tool.pyrefly]", "search-path", f"libs/{library_name}/src"):
+        updated_sections.append("tool.pyrefly.search-path")
 
     if updated_sections:
         pyproject_path.write_text("".join(lines), encoding="utf-8")

--- a/libs/experiment-definition/src/experiment_definition/db.py
+++ b/libs/experiment-definition/src/experiment_definition/db.py
@@ -556,7 +556,7 @@ class DatabaseManager:
 
     def add_hyperparam_config(
         self,
-        params: dict[str, object],
+        params: Mapping[str, object],
         vmap_zone: dict[str, list[str]] | None = None,
     ) -> int:
         """Upsert a hyperparam configuration and return its id.
@@ -737,7 +737,7 @@ class DatabaseManager:
         hostname: str | None = None,
         git_commit: str | None = None,
         git_diff_blob: str | None = None,
-        jax_config: dict[str, object] | None = None,
+        jax_config: Mapping[str, object] | None = None,
     ) -> int:
         """Create a new Execution record in PENDING status and return its id.
 

--- a/libs/experiment-definition/src/experiment_definition/db.py
+++ b/libs/experiment-definition/src/experiment_definition/db.py
@@ -556,7 +556,7 @@ class DatabaseManager:
 
     def add_hyperparam_config(
         self,
-        params: Mapping[str, object],
+        params: Mapping[str, ParameterValue],
         vmap_zone: dict[str, list[str]] | None = None,
     ) -> int:
         """Upsert a hyperparam configuration and return its id.
@@ -737,7 +737,7 @@ class DatabaseManager:
         hostname: str | None = None,
         git_commit: str | None = None,
         git_diff_blob: str | None = None,
-        jax_config: Mapping[str, object] | None = None,
+        jax_config: Mapping[str, ParameterValue] | None = None,
     ) -> int:
         """Create a new Execution record in PENDING status and return its id.
 

--- a/libs/rl-agents/src/rl_agents/double_dqn.py
+++ b/libs/rl-agents/src/rl_agents/double_dqn.py
@@ -9,19 +9,19 @@ The only change from vanilla DQN is in the target computation:
     Double DQN:    target = r + γ · Q_target(s', argmax_a' Q_online(s', a'))
 """
 
-from typing import TYPE_CHECKING, Literal, cast
+from typing import Literal, cast
 
 import jax
 import jax.numpy as jnp
 import optax
-from chex import dataclass
 from flax.training.train_state import TrainState
 from rl_components.buffers import ReplayBuffer
+from rl_components.structs import chex_struct
 
 from rl_agents.dqn import _EnvLike, _make_q_network
 
 
-@dataclass(frozen=True)
+@chex_struct(frozen=True, kw_only=True)
 class DoubleDQNConfig:
     LR: float = 3e-4
     BUFFER_SIZE: int = 100_000
@@ -38,27 +38,6 @@ class DoubleDQNConfig:
     ENV_NAME: str = "MountainCar-v0"
     SEED: int = 42
     NETWORK_PRESET: Literal["mlp", "nature_cnn"] = "mlp"
-
-    if TYPE_CHECKING:
-        def __init__(
-            self,
-            *,
-            LR: float = 3e-4,
-            BUFFER_SIZE: int = 100_000,
-            BATCH_SIZE: int = 64,
-            TOTAL_TIMESTEPS: int = 200_000,
-            LEARNING_STARTS: int = 1_000,
-            TRAIN_FREQUENCY: int = 1,
-            TARGET_NETWORK_FREQUENCY: int = 1_000,
-            GAMMA: float = 0.99,
-            TAU: float = 1.0,
-            EPSILON_START: float = 1.0,
-            EPSILON_END: float = 0.05,
-            EPSILON_FRACTION: float = 0.5,
-            ENV_NAME: str = "MountainCar-v0",
-            SEED: int = 42,
-            NETWORK_PRESET: Literal["mlp", "nature_cnn"] = "mlp",
-        ) -> None: ...
 
 
 def make_train(config: DoubleDQNConfig, env: object, env_params: object | None = None):

--- a/libs/rl-agents/src/rl_agents/dqn.py
+++ b/libs/rl-agents/src/rl_agents/dqn.py
@@ -4,14 +4,14 @@ import flax.linen as nn
 import jax
 import jax.numpy as jnp
 import optax
-from chex import dataclass
 from flax.training.train_state import TrainState
 from jax_nn.initializers import legacy_dqn_uniform
 from jax_nn.layers import NatureCNN
 from rl_components.buffers import ReplayBuffer
+from rl_components.structs import chex_struct
 
 
-@dataclass(frozen=True)
+@chex_struct(frozen=True, kw_only=True)
 class DQNConfig:
     LR: float = 3e-4
     BUFFER_SIZE: int = 100_000
@@ -28,27 +28,6 @@ class DQNConfig:
     ENV_NAME: str = "MountainCar-v0"
     SEED: int = 42
     NETWORK_PRESET: Literal["mlp", "nature_cnn"] = "mlp"
-
-    if TYPE_CHECKING:
-        def __init__(
-            self,
-            *,
-            LR: float = 3e-4,
-            BUFFER_SIZE: int = 100_000,
-            BATCH_SIZE: int = 64,
-            TOTAL_TIMESTEPS: int = 200_000,
-            LEARNING_STARTS: int = 1_000,
-            TRAIN_FREQUENCY: int = 1,
-            TARGET_NETWORK_FREQUENCY: int = 1_000,
-            GAMMA: float = 0.99,
-            TAU: float = 1.0,
-            EPSILON_START: float = 1.0,
-            EPSILON_END: float = 0.05,
-            EPSILON_FRACTION: float = 0.5,
-            ENV_NAME: str = "MountainCar-v0",
-            SEED: int = 42,
-            NETWORK_PRESET: Literal["mlp", "nature_cnn"] = "mlp",
-        ) -> None: ...
 
 
 class QNetwork(nn.Module):
@@ -99,7 +78,8 @@ class _EnvLike(Protocol):
 
 
 class _HasNetworkPreset(Protocol):
-    NETWORK_PRESET: Literal["mlp", "nature_cnn"]
+    @property
+    def NETWORK_PRESET(self) -> Literal["mlp", "nature_cnn"]: ...
 
 
 class NatureQNetwork(nn.Module):

--- a/libs/rl-agents/src/rl_agents/dueling_dqn.py
+++ b/libs/rl-agents/src/rl_agents/dueling_dqn.py
@@ -15,16 +15,16 @@ import flax.linen as nn
 import jax
 import jax.numpy as jnp
 import optax
-from chex import dataclass
 from flax.training.train_state import TrainState
 from jax_nn.heads import DuelingHead
 from jax_nn.initializers import stable_orthogonal
 from rl_components.buffers import ReplayBuffer
+from rl_components.structs import chex_struct
 
 from rl_agents.dqn import _EnvLike
 
 
-@dataclass(frozen=True)
+@chex_struct(frozen=True, kw_only=True)
 class DuelingDQNConfig:
     LR: float = 3e-4
     BUFFER_SIZE: int = 100_000
@@ -41,27 +41,6 @@ class DuelingDQNConfig:
     ENV_NAME: str = "MountainCar-v0"
     SEED: int = 42
     NETWORK_PRESET: Literal["mlp", "nature_cnn"] = "mlp"
-
-    if TYPE_CHECKING:
-        def __init__(
-            self,
-            *,
-            LR: float = 3e-4,
-            BUFFER_SIZE: int = 100_000,
-            BATCH_SIZE: int = 64,
-            TOTAL_TIMESTEPS: int = 200_000,
-            LEARNING_STARTS: int = 1_000,
-            TRAIN_FREQUENCY: int = 1,
-            TARGET_NETWORK_FREQUENCY: int = 1_000,
-            GAMMA: float = 0.99,
-            TAU: float = 1.0,
-            EPSILON_START: float = 1.0,
-            EPSILON_END: float = 0.05,
-            EPSILON_FRACTION: float = 0.5,
-            ENV_NAME: str = "MountainCar-v0",
-            SEED: int = 42,
-            NETWORK_PRESET: Literal["mlp", "nature_cnn"] = "mlp",
-        ) -> None: ...
 
 
 class DuelingQNetwork(nn.Module):

--- a/libs/rl-agents/src/rl_agents/sac.py
+++ b/libs/rl-agents/src/rl_agents/sac.py
@@ -1,17 +1,17 @@
-from typing import TYPE_CHECKING, Protocol, cast
+from typing import Protocol, cast
 
 import distrax
 import flax.linen as nn
 import jax
 import jax.numpy as jnp
 import optax
-from chex import dataclass
 from flax.training.train_state import TrainState
 from flax.typing import VariableDict
 from rl_components.buffers import ReplayBuffer
+from rl_components.structs import chex_struct
 
 
-@dataclass(frozen=True)
+@chex_struct(frozen=True, kw_only=True)
 class SACConfig:
     LR: float = 3e-4
     BUFFER_SIZE: int = 100_000
@@ -25,24 +25,6 @@ class SACConfig:
     TARGET_ENTROPY: float | None = None
     ENV_NAME: str = "MountainCarContinuous-v0"
     SEED: int = 42
-
-    if TYPE_CHECKING:
-        def __init__(
-            self,
-            *,
-            LR: float = 3e-4,
-            BUFFER_SIZE: int = 100_000,
-            BATCH_SIZE: int = 256,
-            TOTAL_TIMESTEPS: int = 1_000_000,
-            LEARNING_STARTS: int = 5_000,
-            TRAIN_FREQUENCY: int = 1,
-            GAMMA: float = 0.99,
-            TAU: float = 0.005,
-            ALPHA: float = 0.2,
-            TARGET_ENTROPY: float | None = None,
-            ENV_NAME: str = "MountainCarContinuous-v0",
-            SEED: int = 42,
-        ) -> None: ...
 
 
 class Critic(nn.Module):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dev = [
     "pytest~=9.0",
     "pytest-benchmark~=5.2",
     "ruff~=0.15",
-    "ty~=0.0",
+    "pyrefly>=1.0",
     "copier~=9.4",
     "typer~=0.12",
     "pyright>=1.1.408",
@@ -83,8 +83,9 @@ ignore = ["E731"]
 quote-style = "double"
 indent-style = "space"
 
-[tool.ty.environment]
-extra-paths = [
+[tool.pyrefly]
+replace-imports-with-any = ["flax.*", "chex.*"]
+search-path = [
     "libs/jax-nn/src",
     "libs/jax-replay/src",
     "libs/jax-utils/src",

--- a/scripts/copilot_hooks.py
+++ b/scripts/copilot_hooks.py
@@ -95,7 +95,7 @@ def run_post_tool_hooks(ctx: HookContext) -> None:
             sub_path = REPO_ROOT / sub
             # Use 'uv run' to ensure we use the workspace's environment
             ruff = sh(["uv", "run", "ruff", "check", "."], sub_path)
-            ty = sh(["uv", "run", "ty", "check", "."], sub_path)
+            pyrefly = sh(["uv", "run", "pyrefly", "check"], sub_path)
             
             # Run pyright only on changed files in this subrepo
             sub_files = [str(REPO_ROOT / f) for f in python_files if find_subrepo(f) == sub]
@@ -104,8 +104,8 @@ def run_post_tool_hooks(ctx: HookContext) -> None:
             failed = []
             if ruff.returncode != 0:
                 failed.append("ruff")
-            if ty.returncode != 0:
-                failed.append("ty")
+            if pyrefly.returncode != 0:
+                failed.append("pyrefly")
             if pyright.returncode != 0:
                 failed.append("pyright")
 
@@ -114,8 +114,8 @@ def run_post_tool_hooks(ctx: HookContext) -> None:
                 err = f"[Hook] Validation failed for subrepo: {sub}\n"
                 if ruff.returncode != 0:
                     err += f"--- Ruff Errors ---\n{ruff.stdout}{ruff.stderr}\n"
-                if ty.returncode != 0:
-                    err += f"--- Ty Errors ---\n{ty.stdout}{ty.stderr}\n"
+                if pyrefly.returncode != 0:
+                    err += f"--- Pyrefly Errors ---\n{pyrefly.stdout}{pyrefly.stderr}\n"
                 if pyright.returncode != 0:
                     err += f"--- Pyright Errors (changed files) ---\n{pyright.stdout}{pyright.stderr}"
                 messages.append(err)

--- a/tests/medium/test_cli_harvest.py
+++ b/tests/medium/test_cli_harvest.py
@@ -17,8 +17,8 @@ def _create_workspace_pyproject(workspace_root: Path) -> None:
         "dependencies = [\n"
         "]\n\n"
         "[tool.uv.sources]\n\n"
-        "[tool.ty.environment]\n"
-        "extra-paths = [\n"
+        "[tool.pyrefly]\n"
+        "search-path = [\n"
         "]\n",
         encoding="utf-8",
     )

--- a/tests/small/test_rl_agents_dqn_atari.py
+++ b/tests/small/test_rl_agents_dqn_atari.py
@@ -162,7 +162,7 @@ class TestDQNAtariTrainPath:
         config_only_args = [DQNAtariConfig(), DQNAtariRuntimeConfig()]
 
         with pytest.raises(TypeError):
-            make_train(*config_only_args)
+            make_train(*config_only_args)  # pyrefly: ignore[bad-argument-type]
 
     def test_make_train_runs_with_env_seam_and_emits_metrics(self):
         config = DQNAtariConfig(

--- a/uv.lock
+++ b/uv.lock
@@ -1282,6 +1282,23 @@ wheels = [
 ]
 
 [[package]]
+name = "pyrefly"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/3a/9045b0097ac58979c7c30a4fa0e673db942d4adbc7b6d439bd54ae58c441/pyrefly-1.0.0.tar.gz", hash = "sha256:5c2b810ffcebd84be71de5df1223651edee951653a66935c6f091e957c452455", size = 5677995, upload-time = "2026-05-12T20:12:46.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/c6/90788819bac9c61dd7bacba53b79f3c12d47ccbe5e51b3d6d89f2387e1d2/pyrefly-1.0.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e355a0908555348ed4b9585ef25c76ff566673e345c866c325f1633f44d890b6", size = 13122950, upload-time = "2026-05-12T20:12:20.711Z" },
+    { url = "https://files.pythonhosted.org/packages/82/91/a3cf2a1e87d336eaa804a1e6fc93266faf6dc2a97eecdbc7eae289628022/pyrefly-1.0.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a7038efc3a40f8294edee339895633cf22db268c0d434cdbcbefc34f78a9ecc3", size = 12599494, upload-time = "2026-05-12T20:12:23.495Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ab/74d1e11e737e99b1c003ecc5d7d2e846c4ea1f328966bfdbbd0ac63fad0a/pyrefly-1.0.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da331ca515ed1c08791da2b5f664cf9c1294c48fd802133262e7d5d51e0f4416", size = 12995507, upload-time = "2026-05-12T20:12:25.951Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ac/2df0899f8464c97e5d995f994c97c5cb5b0f58610432aa90d26d924e1db5/pyrefly-1.0.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c74219d8f3e63cdaa5501a0b21d1c9d37011820f9606728d0ed06f09ae86a878", size = 13947693, upload-time = "2026-05-12T20:12:29.188Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/3e/b247c24321e36f04b7d51f9ccf3df93e5009e4b29939524b36ec2e17dc2a/pyrefly-1.0.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c0d05543b1bb6ee6d64149eb5d6b2fb15aa72d3962d6a97abca0afaca8b0c131", size = 13925803, upload-time = "2026-05-12T20:12:31.904Z" },
+    { url = "https://files.pythonhosted.org/packages/61/16/cfa2d61a4aa1e1f7bca48bb37acd01c6a09db4864b16a54f9587092765ff/pyrefly-1.0.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1382d5b1fcdb49a4de9f34d112d2bddf290a78ff93ee8149492ad5f1077ddffc", size = 13470398, upload-time = "2026-05-12T20:12:35.302Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/2b/6372c7dddb326223e24a46b17efd0d4bd7b4fe22c821e523157577eed2d2/pyrefly-1.0.0-py3-none-win32.whl", hash = "sha256:aa8b5d0e47080e3202a2547b39f7a5a61d2c781c712b3b67884f745ca2c759d2", size = 12222643, upload-time = "2026-05-12T20:12:38.618Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ad/1d23be700b6b2ddaeb362360c7145917a8edbbf7240ae428d40541772fce/pyrefly-1.0.0-py3-none-win_amd64.whl", hash = "sha256:c8abcb0f2082e83c890375128f9cff4aa4d3f210b85eea7b3046c1ae764e77f5", size = 13146369, upload-time = "2026-05-12T20:12:41.423Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/38/16589134f3012fd097a10dcc85771555f1a5fb76e04b682597180743af30/pyrefly-1.0.0-py3-none-win_arm64.whl", hash = "sha256:d150fa9e40e8392832be81c3bcfc0497c146674ce4d0f8e04e1ec29e775ffb8c", size = 12538326, upload-time = "2026-05-12T20:12:43.996Z" },
+]
+
+[[package]]
 name = "pyright"
 version = "1.1.409"
 source = { registry = "https://pypi.org/simple" }
@@ -1452,11 +1469,11 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "copier" },
+    { name = "pyrefly" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-benchmark" },
     { name = "ruff" },
-    { name = "ty" },
     { name = "typer" },
 ]
 
@@ -1493,11 +1510,11 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "copier", specifier = "~=9.4" },
+    { name = "pyrefly", specifier = ">=1.0" },
     { name = "pyright", specifier = ">=1.1.408" },
     { name = "pytest", specifier = "~=9.0" },
     { name = "pytest-benchmark", specifier = "~=5.2" },
     { name = "ruff", specifier = "~=0.15" },
-    { name = "ty", specifier = "~=0.0" },
     { name = "typer", specifier = "~=0.12" },
 ]
 
@@ -1577,6 +1594,7 @@ source = { editable = "libs/rl-components" }
 dependencies = [
     { name = "brax" },
     { name = "chex" },
+    { name = "distrax" },
     { name = "flax" },
     { name = "jax" },
     { name = "jaxatari" },
@@ -1586,6 +1604,7 @@ dependencies = [
 requires-dist = [
     { name = "brax", specifier = "~=0.14" },
     { name = "chex", specifier = "~=0.1" },
+    { name = "distrax", specifier = ">=0.1.8" },
     { name = "flax", specifier = "~=0.12" },
     { name = "jax", specifier = "~=0.9" },
     { name = "jaxatari", git = "https://github.com/k4ntz/JAXAtari?rev=v0.1" },
@@ -1778,31 +1797,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/79/37/5cb90f04990260d2caceb6093560c6cefafca1ec522c1e43be01ca658244/trimesh-4.12.2.tar.gz", hash = "sha256:c8ca31571ac00b112e4e160e66a2d4c3491df321f056bd33806be0485d1af9d9", size = 842220, upload-time = "2026-05-01T00:57:43.333Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/05/98/716a473cfb24750858ddd5d14e6527539dd206583a46408d08eeb2844a75/trimesh-4.12.2-py3-none-any.whl", hash = "sha256:b5b5afa63c5272345f2858f7676bc8c217dc8a89f4fadf6193fe10a81b5ff2aa", size = 741043, upload-time = "2026-05-01T00:57:40.763Z" },
-]
-
-[[package]]
-name = "ty"
-version = "0.0.40"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5a/f8/a754c96967b71de8723f88be17df8738216bd382ffed229cd500b7a24d13/ty-0.0.40.tar.gz", hash = "sha256:883b53dd98f6e5b33ab1c8e1a3cd94b0f29c762ef22cdf1e86aaffb4fd711c67", size = 5726484, upload-time = "2026-05-27T17:55:43.615Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/42/d029a72165ad39f95228b67355927fbd35c821dc8e3e475d49f47c2eeb1e/ty-0.0.40-py3-none-linux_armv6l.whl", hash = "sha256:9defb4742450e569a6a09de286a04008d6c2e815112da4362c88b6eaa2f52a36", size = 11406372, upload-time = "2026-05-27T17:55:49.633Z" },
-    { url = "https://files.pythonhosted.org/packages/23/99/7f8ea09b7e49afbf795cb3341a3217f30f228db7e62a2268ed8cbbf813d6/ty-0.0.40-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:868258a3330db88b683fcafe2c4e936d6226a6312799bf15b585d93557b2d38c", size = 11159782, upload-time = "2026-05-27T17:55:47.405Z" },
-    { url = "https://files.pythonhosted.org/packages/04/d8/1ea745ee97a98b26ae9564d19a430a76a35297cd450e84dcaad22e1f7ee8/ty-0.0.40-py3-none-macosx_11_0_arm64.whl", hash = "sha256:589c81060cf1e7a9ffa2f45bfa35ffd9b9fbd214104e3f13959f113627efcd91", size = 10594139, upload-time = "2026-05-27T17:55:37.206Z" },
-    { url = "https://files.pythonhosted.org/packages/39/1a/fbef21273c6617ff4715b4827ee1c0b6550aa7d1df4b8c43b325545c1cf4/ty-0.0.40-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b06108990cb338d941c315ae6e9ba2fff8f518bc15d3f33e5619ff6a6c9beab", size = 11114156, upload-time = "2026-05-27T17:55:56.11Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/f9/389fc4976d7ec016a7473cf1274bf9c4f491bb54c66649bd022bff9f2b6a/ty-0.0.40-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3913ef37336bec4f96bd2512f8c3a543ca34c259b7170f7eb5adf75b3ed7f04c", size = 11189050, upload-time = "2026-05-27T17:55:54.099Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/a9/4ecabbf4bdda7df0d99d8d3892c6edac0efc8c4cae756a5109178a3d0e86/ty-0.0.40-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8fd1486bd5fe48779a8aa857137f3642a0a9161f5cf57d4380f4a0ecea01c8f3", size = 11664266, upload-time = "2026-05-27T17:55:28.17Z" },
-    { url = "https://files.pythonhosted.org/packages/45/02/0aa78730116507c265afb1d6d5961c583b49d4c2e368c4a49fd81bcae6dc/ty-0.0.40-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1668364d5254a734329917ee66c2c5fdd5665389d41043f6fce0f22ddb32b749", size = 12187743, upload-time = "2026-05-27T17:56:04.337Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/68/ccabf2d173523598271a385c1d3f864dbda23e5ebdc67f5969b9e830ea05/ty-0.0.40-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:43f77a73edb91e5dfa2ab9af7c4cac64614f8cc121f38a8875f22e830d3aba6a", size = 11862999, upload-time = "2026-05-27T17:55:58.087Z" },
-    { url = "https://files.pythonhosted.org/packages/03/8d/6d7ec22771bb23d534797cdb446eb644bccfe7a62b729bb99e7235a02fc3/ty-0.0.40-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1274ce0212ecbfed01bda7c3659c46e8bd0068e32d00c46c790466a95274c3df", size = 11743896, upload-time = "2026-05-27T17:56:00.017Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/a4/f9fa076b010c91cb249b1fcc3476569b7b8462cb4b688da2d04c23a0622f/ty-0.0.40-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:5ee1261dbc363e5cc1a0c5bb0c8612c192bfe53491214df8bc85a540835685f9", size = 11883581, upload-time = "2026-05-27T17:56:02.319Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/0f/5b776a2328c756d574dd4d6afbd30fc24e1ab4b76935c7c3c23f27ebbcb9/ty-0.0.40-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:6220e2cd5cdc4683dd87fb150d195bbd9f1a021395e04cb08bd3c66ea6da6ef8", size = 11093946, upload-time = "2026-05-27T17:55:33.284Z" },
-    { url = "https://files.pythonhosted.org/packages/64/c4/eb23154bae83ad7c2935e9e5916660fb3e31598a92ee232aebd79410480c/ty-0.0.40-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:46b9ed69d01d98ef046afac9983c68336f572605ea2a27b90fbe6f80bfc8d6b7", size = 11210737, upload-time = "2026-05-27T17:55:45.523Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/19/1fb2529703f708cacfd13a89f98613cae2907dfa941b26976467e6119803/ty-0.0.40-py3-none-musllinux_1_2_i686.whl", hash = "sha256:ddbca9fab4406260f141674ab5efcfe7b02bd468e6985e4cdde0a21626e69ffe", size = 11332563, upload-time = "2026-05-27T17:55:41.674Z" },
-    { url = "https://files.pythonhosted.org/packages/87/69/b3f5a8ef26c31204e0391147b3adcdb0674eda3e7d99868478ef168a41c6/ty-0.0.40-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b1fcc082a749e6dc11b68fe9aab0420238bbf2a2374c2c7aa3c22e8c1618b136", size = 11843216, upload-time = "2026-05-27T17:55:35.367Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/e8/20193069d32787f3e1a6ec8940aaa3759d3de8f48f9281bcc0c5cb0939da/ty-0.0.40-py3-none-win32.whl", hash = "sha256:75feb115b3587824c5bdf8f8305e9547b0d1e398e3077b0addc7a1988ea9bb50", size = 10670731, upload-time = "2026-05-27T17:55:31.316Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/f9/8b2aa4da61db81322d4a2f9db227afeb48110ca15ae31d380f64c64ceb63/ty-0.0.40-py3-none-win_amd64.whl", hash = "sha256:b0f905edaad788bd61f779a85801b60a267a25ed57fca05aaddd168d9d8896be", size = 11766211, upload-time = "2026-05-27T17:55:51.898Z" },
-    { url = "https://files.pythonhosted.org/packages/04/87/369056ed46f1b235130ec0595393262f9cd2061ca3dab276d490980f9343/ty-0.0.40-py3-none-win_arm64.whl", hash = "sha256:07da2b09d9130e2c9a257d2a29beb53105835b0256ee5fdb288fe1aab83fee47", size = 11117369, upload-time = "2026-05-27T17:55:39.329Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Replace the Astral `ty` type-checker with Meta's `pyrefly` across the monorepo core.

## Changes

- **`pyproject.toml`**: Replace `ty~=0.0` dep with `pyrefly>=1.0`; replace `[tool.ty.environment]` + `extra-paths` with `[tool.pyrefly]` + `search-path` + `replace-imports-with-any` for flax/chex (suppresses false positives from flax's internal `nn.Module.__init__` scope parameter)
- **`CONTRIBUTING.md`**: Update dev workflow command
- **`ROADMAP.md`**: Update technical debt item
- **`scripts/copilot_hooks.py`**: Replace `ty` invocation with `pyrefly check`
- **`cli/src/research_cli/lifecycle.py`**: Harvest automation now updates `[tool.pyrefly].search-path`
- **`tests/medium/test_cli_harvest.py`**: Update fixture pyproject template
- **`libs/experiment-definition/src/experiment_definition/db.py`**: Fix dict invariance — `params`/`jax_config` changed to `Mapping[str, object]`
- **`tests/small/test_rl_agents_dqn_atari.py`**: Add `# pyrefly: ignore` on intentional-error test call
- **`libs/rl-agents/src/rl_agents/sac.py`**: Fix pre-existing SAC test failure — wrap `log_alpha` in a dict for flax `TrainState` compatibility (newer flax's `apply_gradients` does `OVERWRITE_WITH_GRADIENT in grads` which requires a dict-like pytree, not a raw array)

## Verification

```
uv run pyrefly check  # 0 errors
uv run pytest tests/small tests/medium  # 618/618 pass
```