### PR TITLE
feat: add research-runner plan-execute-record lifecycle library

### DIFF
--- a/libs/experiment-definition/src/experiment_definition/experiment.py
+++ b/libs/experiment-definition/src/experiment_definition/experiment.py
@@ -68,6 +68,10 @@ class Experiment:
         self._component_scope: Component | None = None
         self._condition_stack: list[dict[str, ParameterValue]] = []
 
+    @property
+    def name(self):
+        return self._state.name
+
     # ── Parameter API ─────────────────────────────────────────────────────────
 
     def add_parameter(

--- a/libs/research-runner/pyproject.toml
+++ b/libs/research-runner/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "research-runner"
+version = "0.1.0"
+description = "Stateless experiment runner implementing the ADR-007 plan-execute-record lifecycle."
+requires-python = ">=3.13"
+dependencies = [
+    "experiment-definition",
+]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/libs/research-runner/src/research_runner/git.py
+++ b/libs/research-runner/src/research_runner/git.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import subprocess
+
+
+def capture_git_metadata():
+    try:
+        commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None, None
+
+    try:
+        diff = subprocess.run(
+            ["git", "diff", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        diff = None
+
+    return commit, diff

--- a/libs/research-runner/src/research_runner/runner.py
+++ b/libs/research-runner/src/research_runner/runner.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from datetime import datetime, timezone
+from pathlib import Path
+
+from experiment_definition.db import DatabaseManager, ExperimentRow, PlannedExecution, RunRow
+from experiment_definition.experiment import Experiment
+
+from .git import capture_git_metadata
+from .types import ExecutionContext, ExecutionResult
+
+
+def run_experiment(
+    db_path: Path,
+    experiment: Experiment,
+    train_fn: Callable[[ExecutionContext], ExecutionResult],
+    *,
+    executions_root: Path,
+    metrics_db_path: Path | None = None,
+    max_runs_per_batch: int | None = None,
+    capture_git: bool = True,
+    on_batch_complete: Callable[[Path], None] | None = None,
+):
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    experiment.sync(db_path)
+
+    git_commit, git_diff = capture_git_metadata() if capture_git else (None, None)
+
+    with DatabaseManager(db_path) as database:
+        database.initialize()
+        experiment_row = database.get_experiment(experiment.name)
+        if experiment_row is None:
+            raise RuntimeError(
+                f"Experiment {experiment.name!r} was not synced into {db_path}.",
+            )
+        planned_batches = database.plan_experiment_execution_batches(
+            experiment_row.id,
+            executions_root,
+            max_runs_per_batch=max_runs_per_batch,
+            git_commit=git_commit,
+            git_diff_blob=git_diff,
+        )
+
+    if not planned_batches:
+        return []
+
+    execution_roots: list[Path] = []
+    for planned in planned_batches:
+        root = execute_batch(
+            db_path,
+            planned,
+            train_fn,
+            metrics_db_path=metrics_db_path,
+            capture_git=False,
+        )
+        execution_roots.append(root)
+        if on_batch_complete is not None:
+            on_batch_complete(root)
+
+    return execution_roots
+
+
+def execute_batch(
+    db_path: Path,
+    planned: PlannedExecution,
+    train_fn: Callable[[ExecutionContext], ExecutionResult],
+    *,
+    metrics_db_path: Path | None = None,
+    capture_git: bool = True,
+):
+    with DatabaseManager(db_path) as database:
+        database.initialize()
+        execution_root = Path(planned.root_path)
+        manifest_path = Path(planned.manifest_path)
+        runs = database.list_execution_runs(planned.execution_id)
+        experiment_row = _resolve_experiment(database, runs)
+        hyperparameters = _resolve_hyperparameters(database, runs)
+        seed_values = tuple(run.seed for run in runs)
+        resolved_metrics_db = metrics_db_path or _derive_metrics_db_path(execution_root)
+
+        if capture_git:
+            git_commit, git_diff = capture_git_metadata()
+            database.conn.execute(
+                "UPDATE Executions SET git_commit = COALESCE(?, git_commit), "
+                "git_diff_blob = COALESCE(?, git_diff_blob) WHERE id = ?",
+                (git_commit, git_diff, planned.execution_id),
+            )
+            database.conn.commit()
+
+        database.update_execution_status(
+            planned.execution_id, "RUNNING", start_time=_utc_now(),
+        )
+
+    context = ExecutionContext(
+        execution_id=planned.execution_id,
+        experiment=experiment_row,
+        runs=runs,
+        hyperparameters=hyperparameters,
+        seed_values=seed_values,
+        execution_root=execution_root,
+        metrics_db_path=resolved_metrics_db,
+    )
+
+    try:
+        execution_root.mkdir(parents=True, exist_ok=True)
+        result = train_fn(context)
+
+        manifest = {
+            "experiment_slug": experiment_row.name,
+            "execution_id": planned.execution_id,
+            "root_path": str(execution_root),
+            "metrics_db_path": str(resolved_metrics_db),
+            "seed_values": list(seed_values),
+            "run_ids": [run.id for run in runs],
+            "metadata": result.metadata,
+        }
+        manifest_path.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+        with DatabaseManager(db_path) as database:
+            database.initialize()
+            database.record_execution_artifacts(
+                planned.execution_id,
+                str(execution_root),
+                manifest_path=str(manifest_path),
+                metadata={**result.metadata, "metrics_db_path": str(resolved_metrics_db)},
+            )
+            database.update_execution_status(
+                planned.execution_id, "COMPLETED", end_time=_utc_now(),
+            )
+    except Exception:
+        with DatabaseManager(db_path) as database:
+            database.initialize()
+            database.update_execution_status(
+                planned.execution_id, "FAILED", end_time=_utc_now(),
+            )
+        raise
+
+    return execution_root
+
+
+def _utc_now():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _resolve_experiment(database: DatabaseManager, runs: list[RunRow]):
+    if not runs:
+        raise ValueError("Execution has no linked logical runs.")
+    row = database.conn.execute(
+        "SELECT id, name, description, created_at FROM Experiments WHERE id = ?",
+        (runs[0].experiment_id,),
+    ).fetchone()
+    if row is None:
+        raise RuntimeError(
+            f"Experiment id {runs[0].experiment_id!r} is missing from the registry.",
+        )
+    return ExperimentRow(*row)
+
+
+def _resolve_hyperparameters(database: DatabaseManager, runs: list[RunRow]):
+    hyper_config = database.get_hyperparam_config(runs[0].hyper_id)
+    if hyper_config is None:
+        raise ValueError(f"Missing hyperparameter config for run {runs[0].id}.")
+    return json.loads(hyper_config.json_blob)
+
+
+def _derive_metrics_db_path(execution_root: Path):
+    for candidate in (execution_root, *execution_root.parents):
+        if candidate.name == "executions":
+            return candidate.parent / "metrics.sqlite"
+    raise ValueError(
+        f"Could not derive metrics DB path from execution root {execution_root}. "
+        "Pass metrics_db_path explicitly or use a conventional executions/ directory.",
+    )

--- a/libs/research-runner/src/research_runner/types.py
+++ b/libs/research-runner/src/research_runner/types.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from experiment_definition.db import ExperimentRow, RunRow
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionContext:
+    execution_id: int
+    experiment: ExperimentRow
+    runs: list[RunRow]
+    hyperparameters: dict[str, object]
+    seed_values: tuple[int, ...]
+    execution_root: Path
+    metrics_db_path: Path
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionResult:
+    metadata: dict[str, object] = field(default_factory=dict)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ jax-utils = { workspace = true }
 research-analysis = { workspace = true }
 research-cli = { workspace = true }
 research-instrument = { workspace = true }
+research-runner = { workspace = true }
 research-store = { workspace = true }
 rl-agents = { workspace = true }
 rl-components = { workspace = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "research-analysis",
     "research-cli",
     "research-instrument",
+    "research-runner",
     "research-store",
     "rl-agents",
     "rl-components",

--- a/tests/medium/test_research_runner.py
+++ b/tests/medium/test_research_runner.py
@@ -9,11 +9,9 @@ import pytest
 from experiment_definition.component import Component, ComponentType
 from experiment_definition.db import DatabaseManager, PlannedExecution
 from experiment_definition.experiment import Experiment
-
 from research_runner.git import capture_git_metadata
 from research_runner.runner import _derive_metrics_db_path, execute_batch, run_experiment
 from research_runner.types import ExecutionContext, ExecutionResult
-
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/tests/medium/test_research_runner.py
+++ b/tests/medium/test_research_runner.py
@@ -1,0 +1,249 @@
+"""Medium integration tests for research-runner — plan-execute-record lifecycle."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from experiment_definition.component import Component, ComponentType
+from experiment_definition.db import DatabaseManager, PlannedExecution
+from experiment_definition.experiment import Experiment
+
+from research_runner.git import capture_git_metadata
+from research_runner.runner import _derive_metrics_db_path, execute_batch, run_experiment
+from research_runner.types import ExecutionContext, ExecutionResult
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _trivial_train_fn(ctx: ExecutionContext):
+    return ExecutionResult(metadata={"trained": True})
+
+
+def _make_experiment(name: str = "TestSweep"):
+    algo = Component(name="TestAlgo", path=Path("/nonexistent/algo.py"), type=ComponentType.ALGO)
+    env = Component(name="TestEnv", path=Path("/nonexistent/env.py"), type=ComponentType.ENV)
+    exp = Experiment(name, description="test experiment")
+    exp.add_parameter("seed", [0, 1])
+    with exp.for_component(algo):
+        exp.add_parameter("lr", [1e-3])
+    with exp.for_component(env):
+        exp.add_parameter("gamma", [0.99])
+    return exp
+
+
+# ── run_experiment ────────────────────────────────────────────────────────────
+
+
+class TestRunExperiment:
+    @pytest.fixture()
+    def db_path(self, tmp_path: Path) -> Path:
+        return tmp_path / "experiments.sqlite"
+
+    @pytest.fixture()
+    def executions_root(self, tmp_path: Path) -> Path:
+        return tmp_path / "results" / "executions"
+
+    def test_happy_path(self, db_path: Path, executions_root: Path):
+        """
+        Full lifecycle: sync experiment, plan, execute with trivial callback,
+        verify execution roots, DB status, manifest, and artifacts.
+        """
+        exp = _make_experiment()
+        roots = run_experiment(
+            db_path,
+            exp,
+            _trivial_train_fn,
+            executions_root=executions_root,
+            capture_git=False,
+        )
+
+        assert isinstance(roots, list)
+        assert len(roots) >= 1
+        assert all(isinstance(r, Path) for r in roots)
+
+        with DatabaseManager(db_path) as database:
+            database.initialize()
+            experiment_row = database.get_experiment("TestSweep")
+            assert experiment_row is not None
+
+            for root in roots:
+                manifest_path = root / "manifest.json"
+                assert manifest_path.exists(), f"Manifest missing at {manifest_path}"
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+                assert manifest["experiment_slug"] == "TestSweep"
+                assert manifest["metadata"] == {"trained": True}
+
+                exec_id = manifest["execution_id"]
+                execution = database.get_execution(exec_id)
+                assert execution is not None
+                assert execution.status == "COMPLETED"
+
+                artifacts = database.get_execution_artifacts(exec_id)
+                assert artifacts is not None
+                assert artifacts.root_path == str(root)
+
+    def test_on_batch_complete_invoked(self, db_path: Path, executions_root: Path):
+        """
+        The on_batch_complete callback receives each execution root as it finishes.
+        """
+        exp = _make_experiment()
+        completed_roots: list[Path] = []
+
+        roots = run_experiment(
+            db_path,
+            exp,
+            _trivial_train_fn,
+            executions_root=executions_root,
+            capture_git=False,
+            on_batch_complete=lambda root: completed_roots.append(root),
+        )
+
+        assert len(completed_roots) == len(roots)
+        assert completed_roots == roots
+
+    def test_already_satisfied_returns_empty(self, db_path: Path, executions_root: Path):
+        """
+        Running the same experiment twice returns an empty list because all
+        runs are already COMPLETED.
+        """
+        exp = _make_experiment()
+        first = run_experiment(
+            db_path,
+            exp,
+            _trivial_train_fn,
+            executions_root=executions_root,
+            capture_git=False,
+        )
+        assert len(first) >= 1
+
+        second = run_experiment(
+            db_path,
+            exp,
+            _trivial_train_fn,
+            executions_root=executions_root,
+            capture_git=False,
+        )
+        assert second == []
+
+
+# ── execute_batch ─────────────────────────────────────────────────────────────
+
+
+class TestExecuteBatch:
+    @pytest.fixture()
+    def db_path(self, tmp_path: Path) -> Path:
+        return tmp_path / "experiments.sqlite"
+
+    @pytest.fixture()
+    def executions_root(self, tmp_path: Path) -> Path:
+        return tmp_path / "results" / "executions"
+
+    def _plan_one_batch(self, db_path: Path, executions_root: Path) -> PlannedExecution:
+        exp = _make_experiment()
+        exp.sync(db_path)
+
+        with DatabaseManager(db_path) as database:
+            database.initialize()
+            experiment_row = database.get_experiment("TestSweep")
+            assert experiment_row is not None
+            planned = database.plan_experiment_execution_batches(
+                experiment_row.id,
+                executions_root,
+            )
+            assert len(planned) >= 1
+        return planned[0]
+
+    def test_happy_path(self, db_path: Path, executions_root: Path):
+        """
+        Manually plan a batch then execute it; verify status transitions
+        and manifest creation.
+        """
+        planned = self._plan_one_batch(db_path, executions_root)
+
+        root = execute_batch(
+            db_path,
+            planned,
+            _trivial_train_fn,
+            capture_git=False,
+        )
+
+        assert root == Path(planned.root_path)
+        assert (root / "manifest.json").exists()
+
+        with DatabaseManager(db_path) as database:
+            database.initialize()
+            execution = database.get_execution(planned.execution_id)
+            assert execution is not None
+            assert execution.status == "COMPLETED"
+
+    def test_failure_sets_failed_status(self, db_path: Path, executions_root: Path):
+        """
+        When the train callback raises, the execution status is set to FAILED
+        and the exception propagates.
+        """
+        planned = self._plan_one_batch(db_path, executions_root)
+
+        def _failing_train_fn(ctx: ExecutionContext):
+            raise RuntimeError("Training exploded")
+
+        with pytest.raises(RuntimeError, match="Training exploded"):
+            execute_batch(
+                db_path,
+                planned,
+                _failing_train_fn,
+                capture_git=False,
+            )
+
+        with DatabaseManager(db_path) as database:
+            database.initialize()
+            execution = database.get_execution(planned.execution_id)
+            assert execution is not None
+            assert execution.status == "FAILED"
+
+
+# ── _derive_metrics_db_path ──────────────────────────────────────────────────
+
+
+class TestDeriveMetricsDbPath:
+    def test_with_executions_ancestor(self):
+        """
+        When execution_root contains an 'executions' ancestor directory,
+        metrics.sqlite is placed next to it.
+        """
+        root = Path("/tmp/results/executions/123")
+        result = _derive_metrics_db_path(root)
+        assert result == Path("/tmp/results/metrics.sqlite")
+
+    def test_without_executions_ancestor_raises(self):
+        """
+        When execution_root has no 'executions' ancestor, raises ValueError
+        to force explicit metrics_db_path.
+        """
+        root = Path("/tmp/some/other/path")
+        with pytest.raises(ValueError, match="Pass metrics_db_path explicitly"):
+            _derive_metrics_db_path(root)
+
+    def test_executions_is_root_itself(self):
+        """
+        When the execution_root directory is itself named 'executions',
+        metrics.sqlite is placed in its parent.
+        """
+        root = Path("/tmp/results/executions")
+        result = _derive_metrics_db_path(root)
+        assert result == Path("/tmp/results/metrics.sqlite")
+
+
+# ── capture_git_metadata ─────────────────────────────────────────────────────
+
+
+class TestCaptureGitMetadata:
+    def test_returns_tuple_of_two(self):
+        """
+        capture_git_metadata returns a 2-tuple; each element is str or None.
+        """
+        commit, diff = capture_git_metadata()
+        assert isinstance(commit, (str, type(None)))
+        assert isinstance(diff, (str, type(None)))

--- a/uv.lock
+++ b/uv.lock
@@ -20,6 +20,7 @@ members = [
     "research-core",
     "research-instrument",
     "research-plot",
+    "research-runner",
     "research-store",
     "rl-agents",
     "rl-components",
@@ -1539,6 +1540,17 @@ requires-dist = [
 name = "research-plot"
 version = "0.1.0"
 source = { virtual = "libs/research-plot" }
+
+[[package]]
+name = "research-runner"
+version = "0.1.0"
+source = { editable = "libs/research-runner" }
+dependencies = [
+    { name = "experiment-definition" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "experiment-definition", editable = "libs/experiment-definition" }]
 
 [[package]]
 name = "research-store"


### PR DESCRIPTION
## Summary

Extracts the experiment execution lifecycle from missingness-rl into a reusable research-runner library in core/libs/research-runner/.

## Changes

### experiment-definition
- Expose Experiment.name property for downstream consumers

### research-runner (new library)
- **types.py**: ExecutionContext and ExecutionResult frozen dataclasses — the contract between runner and user-provided training callbacks
- **runner.py**: Core lifecycle — run_experiment() (batch loop until all runs satisfied), execute_batch() (single execution lifecycle: create dir, call train_fn, record artifacts)
- **git.py**: capture_git_metadata() for recording commit SHA and working-tree diff at execution time
- **pyproject.toml**: Package definition depending on experiment-definition

### Workspace registration
- Added research-runner to core pyproject.toml dependencies
- Updated uv.lock

### Tests
- 9 integration tests covering: happy-path batch execution, failure recording, already-satisfied experiments, on_batch_complete callback, metrics DB path derivation, and git metadata capture

## Design

The runner accepts a train_fn(ctx: ExecutionContext) -> ExecutionResult callback, keeping all project-specific training logic in the consumer. The runner handles:
1. Resolving experiments and hyperparameters from the database
2. Planning execution batches
3. Creating execution directories
4. Calling the training callback with full context
5. Recording execution artifacts (including git metadata and metrics DB path)

Built on ADR-007 (database-centric orchestration) and ADR-008 (relational experiment schema).