### PR TITLE
feat(cli): add experiment list/status/plan/run subcommands

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -6,6 +6,8 @@ dependencies = [
     "typer~=0.12",
     "copier~=9.4",
     "PyYAML~=6.0",
+    "experiment-definition",
+    "research-runner",
 ]
 
 [project.scripts]

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "PyYAML~=6.0",
     "experiment-definition",
     "research-runner",
+    "research-cluster",
 ]
 
 [project.scripts]

--- a/cli/src/research_cli/experiment.py
+++ b/cli/src/research_cli/experiment.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import typing
+from collections.abc import Callable
+from pathlib import Path
+
+import typer
+
+from experiment_definition.db import DatabaseManager, ExperimentRow
+from research_runner.types import ExperimentSpec
+
+experiment_app = typer.Typer(help="Manage experiments.")
+
+
+def _discover_specs(module: object, spec_name: str | None) -> dict[str, Callable[[], ExperimentSpec]]:
+    specs: dict[str, Callable[[], ExperimentSpec]] = {}
+    for attr_name in dir(module):
+        if attr_name.startswith("_"):
+            continue
+        obj = getattr(module, attr_name)
+        if not callable(obj):
+            continue
+        try:
+            hints = typing.get_type_hints(obj)
+        except Exception:
+            continue
+        ret = hints.get("return")
+        if ret is ExperimentSpec:
+            specs[attr_name] = obj
+    if spec_name is not None:
+        if spec_name not in specs:
+            typer.echo(f"Error: spec '{spec_name}' not found. Available: {', '.join(sorted(specs))}", err=True)
+            raise typer.Exit(code=1)
+        specs = {spec_name: specs[spec_name]}
+    return specs
+
+
+def _find_project_root(start: Path):
+    for candidate in (start, *start.parents):
+        if (candidate / "pyproject.toml").is_file():
+            return candidate
+    return None
+
+
+def _load_spec_module(spec_file: Path):
+    resolved = spec_file.resolve()
+    if not resolved.is_file():
+        typer.echo(f"Error: spec file '{resolved}' not found.", err=True)
+        raise typer.Exit(code=1)
+
+    project_root = _find_project_root(resolved.parent)
+    if project_root is not None and str(project_root) not in sys.path:
+        sys.path.insert(0, str(project_root))
+
+    module_name = resolved.stem
+    loader_spec = importlib.util.spec_from_file_location(module_name, resolved)
+    if loader_spec is None or loader_spec.loader is None:
+        typer.echo(f"Error: cannot load '{resolved}'.", err=True)
+        raise typer.Exit(code=1)
+    module = importlib.util.module_from_spec(loader_spec)
+    sys.modules[module_name] = module
+    loader_spec.loader.exec_module(module)
+    return module
+
+
+@experiment_app.command("list")
+def list_experiments(
+    db_path: Path = typer.Argument(..., help="Path to the experiment database."),
+):
+    with DatabaseManager(db_path) as db:
+        db.initialize()
+        rows = db.conn.execute(
+            "SELECT name, description FROM Experiments ORDER BY name",
+        ).fetchall()
+
+    typer.echo(f"{'Name':<30} Description")
+    typer.echo("-" * 60)
+    for row in rows:
+        name = row[0]
+        desc = row[1] or ""
+        typer.echo(f"{name:<30} {desc}")
+
+
+@experiment_app.command("status")
+def status(
+    db_path: Path = typer.Argument(..., help="Path to the experiment database."),
+    experiment: str | None = typer.Option(None, "--experiment", help="Filter by experiment slug."),
+):
+    with DatabaseManager(db_path) as db:
+        db.initialize()
+        if experiment:
+            exp_row = db.get_experiment(experiment)
+            if exp_row is None:
+                typer.echo(f"Error: experiment '{experiment}' not found.", err=True)
+                raise typer.Exit(code=1)
+            exp_rows = [exp_row]
+        else:
+            raw = db.conn.execute(
+                "SELECT id, name, description, created_at FROM Experiments ORDER BY name",
+            ).fetchall()
+            exp_rows = [ExperimentRow(*r) for r in raw]
+
+        for exp_row in exp_rows:
+            all_runs = db.list_runs(exp_row.id)
+            unsatisfied = db.list_unsatisfied_runs(exp_row.id)
+            total = len(all_runs)
+            pending = len(unsatisfied)
+            completed = total - pending
+            typer.echo(f"{exp_row.name}: {total} runs ({completed} completed, {pending} pending)")
+
+
+@experiment_app.command("plan")
+def plan(
+    spec_file: Path = typer.Argument(..., help="Path to the Python spec file."),
+    spec: str | None = typer.Option(None, "--spec", help="Run only the named spec factory."),
+    db: str | None = typer.Option(None, "--db", help="Override database path."),
+):
+    module = _load_spec_module(spec_file)
+    specs = _discover_specs(module, spec)
+
+    for name, factory in specs.items():
+        experiment_spec = factory()
+        db_path = Path(db) if db else experiment_spec.db_path
+
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        experiment_spec.experiment.sync(db_path)
+
+        with DatabaseManager(db_path) as database:
+            database.initialize()
+            exp_row = database.get_experiment(experiment_spec.experiment.name)
+            if exp_row is None:
+                typer.echo(f"Error: experiment '{experiment_spec.experiment.name}' not synced.", err=True)
+                raise typer.Exit(code=1)
+            batches = database.list_unsatisfied_run_batches(
+                exp_row.id,
+                max_runs_per_batch=experiment_spec.max_runs_per_batch,
+            )
+
+        typer.echo(f"Spec '{name}': {len(batches)} batch(es) planned")
+        for i, batch in enumerate(batches):
+            typer.echo(f"  Batch {i + 1}: {len(batch.run_ids)} run(s)")
+
+
+@experiment_app.command("run")
+def run(
+    spec_file: Path = typer.Argument(..., help="Path to the Python spec file."),
+    spec: str | None = typer.Option(None, "--spec", help="Run only the named spec factory."),
+    db: str | None = typer.Option(None, "--db", help="Override database path."),
+    executions_root: str | None = typer.Option(None, "--executions-root", help="Override executions root."),
+    max_runs: int | None = typer.Option(None, "--max-runs", help="Override max runs per batch."),
+):
+    from research_runner.runner import run_experiment
+
+    module = _load_spec_module(spec_file)
+    specs = _discover_specs(module, spec)
+
+    for name, factory in specs.items():
+        experiment_spec = factory()
+        db_path = Path(db) if db else experiment_spec.db_path
+        exec_root = Path(executions_root) if executions_root else experiment_spec.executions_root
+        max_runs_per_batch = max_runs if max_runs is not None else experiment_spec.max_runs_per_batch
+
+        typer.echo(f"Running spec '{name}'...")
+        roots = run_experiment(
+            db_path,
+            experiment_spec.experiment,
+            experiment_spec.train_fn,
+            executions_root=exec_root,
+            metrics_db_path=experiment_spec.metrics_db_path,
+            max_runs_per_batch=max_runs_per_batch,
+            capture_git=experiment_spec.capture_git,
+        )
+        typer.echo(f"Spec '{name}': {len(roots)} execution(s) completed")
+        for root in roots:
+            typer.echo(f"  {root}")

--- a/cli/src/research_cli/experiment.py
+++ b/cli/src/research_cli/experiment.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import typer
 
-from experiment_definition.db import DatabaseManager, ExperimentRow
+from experiment_definition.db import DatabaseManager, ExecutionRow, ExperimentRow
 from research_runner.types import ExperimentSpec
 
 experiment_app = typer.Typer(help="Manage experiments.")
@@ -175,3 +175,64 @@ def run(
         typer.echo(f"Spec '{name}': {len(roots)} execution(s) completed")
         for root in roots:
             typer.echo(f"  {root}")
+
+
+@experiment_app.command("executions")
+def executions(
+    db_path: Path = typer.Argument(..., help="Path to the experiment database."),
+    experiment: str | None = typer.Option(None, "--experiment", help="Filter by experiment name."),
+    status: str | None = typer.Option(None, "--status", help="Filter by execution status."),
+    git_commit: str | None = typer.Option(None, "--git-commit", help="Filter by git commit SHA."),
+):
+    with DatabaseManager(db_path) as db:
+        db.initialize()
+        experiment_id = None
+        if experiment is not None:
+            exp_row = db.get_experiment(experiment)
+            if exp_row is None:
+                typer.echo(f"Error: experiment '{experiment}' not found.", err=True)
+                raise typer.Exit(code=1)
+            experiment_id = exp_row.id
+        rows = db.list_executions(experiment_id, status=status, git_commit=git_commit)
+
+    typer.echo(f"{'ID':<6} {'Status':<12} {'Hostname':<20} {'Start Time':<22} {'Git Commit':<10}")
+    typer.echo("-" * 70)
+    for row in rows:
+        commit_display = row.git_commit[:8] if row.git_commit else "\u2014"
+        hostname_display = row.hostname or "\u2014"
+        start_display = row.start_time or "\u2014"
+        typer.echo(f"{row.id:<6} {row.status:<12} {hostname_display:<20} {start_display:<22} {commit_display:<10}")
+
+
+@experiment_app.command("invalidate")
+def invalidate(
+    db_path: Path = typer.Argument(..., help="Path to the experiment database."),
+    execution: list[int] | None = typer.Option(None, "--execution", help="Execution ID(s) to invalidate."),
+    git_commit: str | None = typer.Option(None, "--git-commit", help="Invalidate all executions for a git commit."),
+):
+    if not execution and not git_commit:
+        typer.echo("Error: at least one of --execution or --git-commit must be provided.", err=True)
+        raise typer.Exit(code=1)
+
+    parts = []
+    if execution:
+        parts.append(f"execution ID(s): {', '.join(str(e) for e in execution)}")
+    if git_commit:
+        parts.append(f"git commit: {git_commit[:8]}")
+    typer.confirm(f"Invalidate executions matching {'; '.join(parts)}?", abort=True)
+
+    invalidated: list[int] = []
+    with DatabaseManager(db_path) as db:
+        db.initialize()
+        if execution:
+            for eid in execution:
+                if db.invalidate_execution(eid):
+                    invalidated.append(eid)
+        if git_commit:
+            already = set(invalidated)
+            invalidated.extend(eid for eid in db.invalidate_executions_by_commit(git_commit) if eid not in already)
+
+    if not invalidated:
+        typer.echo("Warning: no executions were invalidated.", err=True)
+    else:
+        typer.echo(f"Invalidated {len(invalidated)} execution(s): {', '.join(str(i) for i in invalidated)}")

--- a/cli/src/research_cli/experiment.py
+++ b/cli/src/research_cli/experiment.py
@@ -236,3 +236,106 @@ def invalidate(
         typer.echo("Warning: no executions were invalidated.", err=True)
     else:
         typer.echo(f"Invalidated {len(invalidated)} execution(s): {', '.join(str(i) for i in invalidated)}")
+
+
+@experiment_app.command("execute-batch")
+def execute_batch_cmd(
+    db_path: Path = typer.Argument(..., help="Path to the experiment database."),
+    execution_id: int = typer.Option(..., "--execution-id", help="Planned execution ID to run."),
+    spec_file: Path = typer.Option(..., "--spec-file", help="Path to the Python spec file."),
+    spec: str = typer.Option(..., "--spec", help="Name of the spec factory."),
+):
+    from research_runner.runner import execute_batch
+
+    module = _load_spec_module(spec_file)
+    specs = _discover_specs(module, spec)
+    if len(specs) != 1:
+        typer.echo(f"Error: expected exactly one spec, found {len(specs)}.", err=True)
+        raise typer.Exit(code=1)
+
+    experiment_spec = next(iter(specs.values()))()
+
+    with DatabaseManager(db_path) as database:
+        database.initialize()
+        planned = database.get_planned_execution(execution_id)
+
+    if planned is None:
+        typer.echo(f"Error: planned execution {execution_id} not found.", err=True)
+        raise typer.Exit(code=1)
+
+    root = execute_batch(
+        db_path,
+        planned,
+        experiment_spec.train_fn,
+        metrics_db_path=experiment_spec.metrics_db_path,
+        capture_git=experiment_spec.capture_git,
+    )
+    typer.echo(f"Execution {execution_id} completed: {root}")
+
+
+@experiment_app.command("submit")
+def submit(
+    spec_file: Path = typer.Argument(..., help="Path to the Python spec file."),
+    spec: str | None = typer.Option(None, "--spec", help="Run only the named spec factory."),
+    db: str | None = typer.Option(None, "--db", help="Override database path."),
+    account: str | None = typer.Option(None, "--account", help="Slurm account."),
+    partition: str | None = typer.Option(None, "--partition", help="Slurm partition."),
+    time: str = typer.Option("2:59:00", "--time", help="Slurm time limit."),
+    cpus_per_task: int = typer.Option(1, "--cpus-per-task", help="CPUs per task."),
+    mem_per_cpu: str = typer.Option("4G", "--mem-per-cpu", help="Memory per CPU."),
+    gpus: int | None = typer.Option(None, "--gpus", help="GPUs per task."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Write script without submitting."),
+    script_path: Path | None = typer.Option(None, "--script-path", help="Override output script path."),
+):
+    from research_cluster.config import SlurmConfig
+    from research_cluster.submit import submit_experiment
+
+    module = _load_spec_module(spec_file)
+    specs = _discover_specs(module, spec)
+
+    for name, factory in specs.items():
+        experiment_spec = factory()
+        db_path = Path(db) if db else experiment_spec.db_path
+
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        experiment_spec.experiment.sync(db_path)
+
+        with DatabaseManager(db_path) as database:
+            database.initialize()
+            exp_row = database.get_experiment(experiment_spec.experiment.name)
+            if exp_row is None:
+                typer.echo(f"Error: experiment '{experiment_spec.experiment.name}' not synced.", err=True)
+                raise typer.Exit(code=1)
+            planned = database.plan_experiment_execution_batches(
+                exp_row.id,
+                experiment_spec.executions_root,
+                max_runs_per_batch=experiment_spec.max_runs_per_batch,
+            )
+
+        if not planned:
+            typer.echo(f"Spec '{name}': no unsatisfied batches, skipping.")
+            continue
+
+        execution_ids = [p.execution_id for p in planned]
+        config = SlurmConfig(
+            account=account,
+            partition=partition,
+            time=time,
+            cpus_per_task=cpus_per_task,
+            mem_per_cpu=mem_per_cpu,
+            gpus_per_task=gpus,
+        )
+        job_result = submit_experiment(
+            config,
+            execution_ids,
+            db_path,
+            spec_file,
+            name,
+            script_path=script_path,
+            dry_run=dry_run,
+        )
+
+        if dry_run:
+            typer.echo(f"Spec '{name}': {len(planned)} batch(es) planned (dry-run, not submitted)")
+        else:
+            typer.echo(f"Spec '{name}': submitted {len(planned)} batch(es) — {job_result}")

--- a/cli/src/research_cli/main.py
+++ b/cli/src/research_cli/main.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import typer
 
 from research_cli.doctor import doctor_command
+from research_cli.experiment import experiment_app
 from research_cli.lifecycle import eject, harvest
 from research_cli.project import project_app
 from research_cli.workspace import workspace_app
@@ -8,6 +11,7 @@ from research_cli.workspace import workspace_app
 app = typer.Typer(help="RL Research Monorepo Management CLI")
 app.add_typer(project_app, name="project")
 app.add_typer(workspace_app, name="workspace")
+app.add_typer(experiment_app, name="experiment")
 app.command(name="doctor", help="Run a read-only diagnostic sweep for this workspace.")(doctor_command)
 app.command(help="Eject a shared library into a project-local components/ package.")(eject)
 app.command(help="Harvest a project-local component into libs/.")(harvest)

--- a/cli/src/research_cli/templates/pyproject.toml.tpl
+++ b/cli/src/research_cli/templates/pyproject.toml.tpl
@@ -21,4 +21,5 @@ members = [
 
 [tool.uv.sources]
 experiment-definition = {{ workspace = true }}
+research-cluster = {{ workspace = true }}
 research-runner = {{ workspace = true }}

--- a/cli/src/research_cli/templates/pyproject.toml.tpl
+++ b/cli/src/research_cli/templates/pyproject.toml.tpl
@@ -18,3 +18,7 @@ members = [
     "core/libs/*",
     "projects/*",
 ]
+
+[tool.uv.sources]
+experiment-definition = {{ workspace = true }}
+research-runner = {{ workspace = true }}

--- a/libs/experiment-definition/src/experiment_definition/db.py
+++ b/libs/experiment-definition/src/experiment_definition/db.py
@@ -1037,6 +1037,25 @@ class DatabaseManager:
         ).fetchall()
         return [ExecutionRow(*row) for row in rows]
 
+    def get_planned_execution(self, execution_id: int):
+        execution = self.get_execution(execution_id)
+        if execution is None:
+            return None
+        artifacts = self.get_execution_artifacts(execution_id)
+        if artifacts is None:
+            return None
+        runs = self.list_execution_runs(execution_id)
+        run_ids = [r.id for r in runs]
+        metadata = json.loads(artifacts.metadata_json) if artifacts.metadata_json else {}
+        return PlannedExecution(
+            execution_id=execution_id,
+            run_ids=run_ids,
+            root_path=artifacts.root_path,
+            manifest_path=artifacts.manifest_path or "",
+            static_config_json=metadata.get("static_config_json", "{}"),
+            vmap_zone_json=metadata.get("vmap_zone_json"),
+        )
+
 
 def _static_config_json(hyper_json: str, vmap_zone_json: str | None) -> str:
     hyper_params = json.loads(hyper_json)

--- a/libs/experiment-definition/src/experiment_definition/db.py
+++ b/libs/experiment-definition/src/experiment_definition/db.py
@@ -981,6 +981,62 @@ class DatabaseManager:
                 (execution_id, run_id),
             )
 
+    def invalidate_execution(self, execution_id: int):
+        existing = self.get_execution(execution_id)
+        if existing is None:
+            return False
+        self.update_execution_status(execution_id, "INVALID")
+        return True
+
+    def invalidate_executions_by_commit(self, git_commit: str):
+        with self.conn:
+            rows = self.conn.execute(
+                "SELECT id FROM Executions WHERE git_commit = ? AND status IN ('COMPLETED', 'FAILED')",
+                (git_commit,),
+            ).fetchall()
+            if not rows:
+                return []
+            self.conn.execute(
+                "UPDATE Executions SET status = 'INVALID' WHERE git_commit = ? AND status IN ('COMPLETED', 'FAILED')",
+                (git_commit,),
+            )
+        return [int(row[0]) for row in rows]
+
+    def list_executions(
+        self,
+        experiment_id: int | None = None,
+        *,
+        status: str | None = None,
+        git_commit: str | None = None,
+    ):
+        clauses: list[str] = []
+        params: list[object] = []
+
+        if experiment_id is not None:
+            clauses.append(
+                "e.id IN ("
+                "  SELECT er.execution_id FROM ExecutionRuns er"
+                "  INNER JOIN Runs r ON r.id = er.run_id"
+                "  WHERE r.experiment_id = ?"
+                ")"
+            )
+            params.append(experiment_id)
+        if status is not None:
+            clauses.append("e.status = ?")
+            params.append(status)
+        if git_commit is not None:
+            clauses.append("e.git_commit = ?")
+            params.append(git_commit)
+
+        where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+        rows = self.conn.execute(
+            "SELECT e.id, e.status, e.hostname, e.start_time, e.end_time, "
+            "e.git_commit, e.git_diff_blob, e.jax_config_json "
+            f"FROM Executions e{where} ORDER BY e.id DESC",
+            params,
+        ).fetchall()
+        return [ExecutionRow(*row) for row in rows]
+
 
 def _static_config_json(hyper_json: str, vmap_zone_json: str | None) -> str:
     hyper_params = json.loads(hyper_json)

--- a/libs/research-cluster/pyproject.toml
+++ b/libs/research-cluster/pyproject.toml
@@ -1,13 +1,10 @@
 [project]
 name = "research-cluster"
 version = "0.1.0"
-description = "Stub — not yet implemented"
+description = "Slurm job array mapper and cluster submission for research experiments"
 requires-python = ">=3.13"
-dependencies = []
+dependencies = ["experiment-definition"]
 
 [build-system]
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
-
-[tool.uv]
-package = false

--- a/libs/research-cluster/src/research_cluster/__init__.py
+++ b/libs/research-cluster/src/research_cluster/__init__.py
@@ -1,2 +1,2 @@
-"""research_cluster: stub library — not yet implemented."""
+"""research_cluster: Slurm job array mapper and cluster submission."""
 

--- a/libs/research-cluster/src/research_cluster/config.py
+++ b/libs/research-cluster/src/research_cluster/config.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class SlurmConfig:
+    account: str | None = None
+    partition: str | None = None
+    time: str = "2:59:00"
+    cpus_per_task: int = 1
+    mem_per_cpu: str = "4G"
+    gpus_per_task: int | None = None
+    modules: list[str] = field(default_factory=list)
+    setup_commands: list[str] = field(default_factory=list)
+    log_path: str = "slurm-%A_%a.out"
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]):
+        return cls(**{k: v for k, v in d.items() if k in cls.__dataclass_fields__})
+
+    @classmethod
+    def from_json(cls, path: str):
+        import json
+        from pathlib import Path
+
+        with Path(path).open() as f:
+            return cls.from_dict(json.load(f))

--- a/libs/research-cluster/src/research_cluster/script.py
+++ b/libs/research-cluster/src/research_cluster/script.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from .config import SlurmConfig
+
+
+def build_sbatch_flags(config: SlurmConfig):
+    flags: list[str] = []
+    if config.account:
+        flags.append(f"#SBATCH --account={config.account}")
+    if config.partition:
+        flags.append(f"#SBATCH --partition={config.partition}")
+    flags.append(f"#SBATCH --time={config.time}")
+    flags.append(f"#SBATCH --cpus-per-task={config.cpus_per_task}")
+    flags.append(f"#SBATCH --mem-per-cpu={config.mem_per_cpu}")
+    if config.gpus_per_task is not None:
+        flags.append(f"#SBATCH --gpus-per-task={config.gpus_per_task}")
+    flags.append(f"#SBATCH --output={config.log_path}")
+    return "\n".join(flags)
+
+
+def build_job_script(
+    config: SlurmConfig,
+    execution_ids: list[int],
+    db_path: Path,
+    spec_file: Path,
+    spec_name: str,
+    *,
+    working_dir: Path | None = None,
+):
+    if not execution_ids:
+        raise ValueError("execution_ids must not be empty.")
+
+    id_list = " ".join(str(eid) for eid in execution_ids)
+
+    lines = [
+        "#!/bin/bash",
+        build_sbatch_flags(config),
+        f"#SBATCH --array=0-{len(execution_ids) - 1}",
+        "",
+        "set -euo pipefail",
+    ]
+
+    if working_dir:
+        lines.append(f'cd "{working_dir}"')
+
+    if config.modules:
+        lines.append("")
+        lines.append("# Load modules")
+        lines.extend(f"module load {m}" for m in config.modules)
+
+    if config.setup_commands:
+        lines.append("")
+        lines.append("# Setup")
+        lines.extend(config.setup_commands)
+
+    lines.extend([
+        "",
+        "# Map array index to execution ID",
+        f"EXECUTION_IDS=({id_list})",
+        "EXECUTION_ID=${EXECUTION_IDS[$SLURM_ARRAY_TASK_ID]}",
+        "",
+        'echo "Array task $SLURM_ARRAY_TASK_ID -> Execution $EXECUTION_ID"',
+        "",
+        "uv run research experiment execute-batch \\",
+        f'    "{db_path}" \\',
+        '    --execution-id "$EXECUTION_ID" \\',
+        f'    --spec-file "{spec_file}" \\',
+        f'    --spec "{spec_name}"',
+        "",
+    ])
+
+    return "\n".join(lines)
+
+
+def write_job_script(
+    script: str,
+    output_path: Path,
+):
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(script)
+    return output_path

--- a/libs/research-cluster/src/research_cluster/submit.py
+++ b/libs/research-cluster/src/research_cluster/submit.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from .config import SlurmConfig
+from .script import build_job_script, write_job_script
+
+
+def submit_experiment(
+    config: SlurmConfig,
+    execution_ids: list[int],
+    db_path: Path,
+    spec_file: Path,
+    spec_name: str,
+    *,
+    working_dir: Path | None = None,
+    script_path: Path | None = None,
+    dry_run: bool = False,
+):
+    script = build_job_script(
+        config,
+        execution_ids,
+        db_path,
+        spec_file,
+        spec_name,
+        working_dir=working_dir,
+    )
+
+    out_path = script_path or Path("slurm_submit.sh")
+    write_job_script(script, out_path)
+
+    if dry_run:
+        return None
+
+    result = subprocess.run(
+        ["sbatch", str(out_path)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()

--- a/libs/research-runner/src/research_runner/types.py
+++ b/libs/research-runner/src/research_runner/types.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from experiment_definition.db import ExperimentRow, RunRow
+from experiment_definition.experiment import Experiment
 
 
 @dataclass(frozen=True, slots=True)
@@ -20,3 +22,14 @@ class ExecutionContext:
 @dataclass(frozen=True, slots=True)
 class ExecutionResult:
     metadata: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class ExperimentSpec:
+    experiment: Experiment
+    train_fn: Callable[[ExecutionContext], ExecutionResult]
+    db_path: Path
+    executions_root: Path
+    metrics_db_path: Path | None = None
+    max_runs_per_batch: int | None = None
+    capture_git: bool = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
     "flax~=0.12",
     "gymnax~=0.0",
     "jax~=0.9",
-    "jaxatari @ git+https://github.com/k4ntz/JAXAtari@v0.1",
     "jaxlib~=0.9",
     "jaxtyping~=0.3",
     "matplotlib>=3.9",
@@ -54,6 +53,7 @@ jax-replay = { workspace = true }
 jax-utils = { workspace = true }
 research-analysis = { workspace = true }
 research-cli = { workspace = true }
+research-cluster = { workspace = true }
 research-instrument = { workspace = true }
 research-runner = { workspace = true }
 research-store = { workspace = true }

--- a/tests/medium/test_bootstrap_truthful_path.py
+++ b/tests/medium/test_bootstrap_truthful_path.py
@@ -66,6 +66,44 @@ def _write_fake_jax_package(core_root: Path) -> None:
     )
 
 
+def _write_fake_stub_package(core_root: Path, dist_name: str, import_name: str) -> None:
+    package_root = core_root / "libs" / dist_name
+    src_dir = package_root / "src" / import_name
+    src_dir.mkdir(parents=True, exist_ok=True)
+    (package_root / "pyproject.toml").write_text(
+        "[project]\n"
+        f'name = "{dist_name}"\n'
+        'version = "0.0.0"\n'
+        f'description = "Test-only fake {dist_name} package"\n'
+        'requires-python = ">=3.13"\n'
+        "dependencies = []\n\n"
+        "[build-system]\n"
+        'requires = ["setuptools>=61.0"]\n'
+        'build-backend = "setuptools.build_meta"\n\n'
+        "[tool.setuptools.packages.find]\n"
+        'where = ["src"]\n',
+        encoding="utf-8",
+    )
+    (src_dir / "__init__.py").write_text("", encoding="utf-8")
+    if import_name == "experiment_definition":
+        (src_dir / "db.py").write_text(
+            "from collections import namedtuple\n"
+            "ExperimentRow = namedtuple('ExperimentRow', ['id', 'name', 'description', 'created_at'])\n"
+            "class DatabaseManager:\n"
+            "    def __init__(self, *a, **kw): pass\n"
+            "    def __enter__(self): return self\n"
+            "    def __exit__(self, *a): pass\n"
+            "    def initialize(self): pass\n",
+            encoding="utf-8",
+        )
+        (src_dir / "experiment.py").write_text("", encoding="utf-8")
+    elif import_name == "research_runner":
+        (src_dir / "types.py").write_text(
+            "class ExperimentSpec: pass\n",
+            encoding="utf-8",
+        )
+
+
 def _create_core_fixture(repo_root: Path, core_root: Path, env: dict[str, str]) -> None:
     _init_repo(core_root, env)
     (core_root / "libs").mkdir(parents=True, exist_ok=True)
@@ -77,6 +115,8 @@ def _create_core_fixture(repo_root: Path, core_root: Path, env: dict[str, str]) 
     )
     shutil.copy2(repo_root / "cli" / "pyproject.toml", core_root / "cli" / "pyproject.toml")
     _write_fake_jax_package(core_root)
+    _write_fake_stub_package(core_root, "experiment-definition", "experiment_definition")
+    _write_fake_stub_package(core_root, "research-runner", "research_runner")
     _git(core_root, env, "add", ".")
     _git(core_root, env, "commit", "-m", "fixture core")
 

--- a/tests/medium/test_bootstrap_truthful_path.py
+++ b/tests/medium/test_bootstrap_truthful_path.py
@@ -89,6 +89,7 @@ def _write_fake_stub_package(core_root: Path, dist_name: str, import_name: str) 
         (src_dir / "db.py").write_text(
             "from collections import namedtuple\n"
             "ExperimentRow = namedtuple('ExperimentRow', ['id', 'name', 'description', 'created_at'])\n"
+            "ExecutionRow = namedtuple('ExecutionRow', ['id', 'experiment_id', 'status', 'created_at'])\n"
             "class DatabaseManager:\n"
             "    def __init__(self, *a, **kw): pass\n"
             "    def __enter__(self): return self\n"
@@ -117,6 +118,7 @@ def _create_core_fixture(repo_root: Path, core_root: Path, env: dict[str, str]) 
     _write_fake_jax_package(core_root)
     _write_fake_stub_package(core_root, "experiment-definition", "experiment_definition")
     _write_fake_stub_package(core_root, "research-runner", "research_runner")
+    _write_fake_stub_package(core_root, "research-cluster", "research_cluster")
     _git(core_root, env, "add", ".")
     _git(core_root, env, "commit", "-m", "fixture core")
 

--- a/tests/medium/test_experiment_cli.py
+++ b/tests/medium/test_experiment_cli.py
@@ -143,3 +143,94 @@ def test_spec_discovery_ignores_non_spec_functions(tmp_path: Path):
     specs = _discover_specs(loaded, None)
     assert "my_spec" in specs
     assert "not_a_spec" not in specs
+
+
+# ---------------------------------------------------------------------------
+# Executions listing
+# ---------------------------------------------------------------------------
+
+
+def test_executions_shows_execution_table(tmp_path: Path):
+    db_path = tmp_path / "exec.sqlite"
+    with DatabaseManager(db_path) as db:
+        db.initialize()
+        eid = db.add_execution(hostname="gpu-node-01", git_commit="abc12345deadbeef")
+        db.update_execution_status(eid, "COMPLETED", start_time="2026-05-01T10:00:00Z")
+
+    result = runner.invoke(app, ["experiment", "executions", str(db_path)])
+    assert result.exit_code == 0
+    assert "COMPLETED" in result.output
+    assert "gpu-node-01" in result.output
+    assert "abc12345" in result.output
+
+
+def test_executions_empty_db(tmp_path: Path):
+    db_path = tmp_path / "empty_exec.sqlite"
+    with DatabaseManager(db_path) as db:
+        db.initialize()
+
+    result = runner.invoke(app, ["experiment", "executions", str(db_path)])
+    assert result.exit_code == 0
+    assert "ID" in result.output
+    assert "Status" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Invalidation CLI
+# ---------------------------------------------------------------------------
+
+
+def test_invalidate_by_execution_id(tmp_path: Path):
+    db_path = tmp_path / "inv.sqlite"
+    with DatabaseManager(db_path) as db:
+        db.initialize()
+        eid = db.add_execution(hostname="node01")
+        db.update_execution_status(eid, "COMPLETED")
+
+    result = runner.invoke(
+        app,
+        ["experiment", "invalidate", str(db_path), "--execution", str(eid)],
+        input="y\n",
+    )
+    assert result.exit_code == 0
+    assert "Invalidated 1" in result.output
+
+
+def test_invalidate_by_git_commit(tmp_path: Path):
+    db_path = tmp_path / "inv_commit.sqlite"
+    with DatabaseManager(db_path) as db:
+        db.initialize()
+        e1 = db.add_execution(hostname="n1", git_commit="fff999abcdef")
+        db.update_execution_status(e1, "COMPLETED")
+        e2 = db.add_execution(hostname="n2", git_commit="fff999abcdef")
+        db.update_execution_status(e2, "COMPLETED")
+
+    result = runner.invoke(
+        app,
+        ["experiment", "invalidate", str(db_path), "--git-commit", "fff999abcdef"],
+        input="y\n",
+    )
+    assert result.exit_code == 0
+    assert "Invalidated 2" in result.output
+
+
+def test_invalidate_no_args_fails(tmp_path: Path):
+    db_path = tmp_path / "inv_noargs.sqlite"
+    with DatabaseManager(db_path) as db:
+        db.initialize()
+
+    result = runner.invoke(app, ["experiment", "invalidate", str(db_path)])
+    assert result.exit_code == 1
+
+
+def test_invalidate_nonexistent_warns(tmp_path: Path):
+    db_path = tmp_path / "inv_none.sqlite"
+    with DatabaseManager(db_path) as db:
+        db.initialize()
+
+    result = runner.invoke(
+        app,
+        ["experiment", "invalidate", str(db_path), "--execution", "99999"],
+        input="y\n",
+    )
+    assert "no executions were invalidated" in (result.output + (result.stderr or "")).lower()

--- a/tests/medium/test_experiment_cli.py
+++ b/tests/medium/test_experiment_cli.py
@@ -234,3 +234,76 @@ def test_invalidate_nonexistent_warns(tmp_path: Path):
         input="y\n",
     )
     assert "no executions were invalidated" in (result.output + (result.stderr or "")).lower()
+
+
+# ---------------------------------------------------------------------------
+# Execute-batch CLI
+# ---------------------------------------------------------------------------
+
+
+def test_execute_batch_runs_planned_execution(tmp_path: Path):
+    db_path = tmp_path / "eb.sqlite"
+    executions_root = tmp_path / "executions"
+    spec_file = _write_spec_file(tmp_path, db_path, executions_root)
+
+    # Sync experiment and plan execution batches
+    plan_result = runner.invoke(app, ["experiment", "plan", str(spec_file)])
+    assert plan_result.exit_code == 0, plan_result.output
+
+    with DatabaseManager(db_path) as database:
+        database.initialize()
+        exp_row = database.get_experiment("test-experiment")
+        assert exp_row is not None
+        planned = database.plan_experiment_execution_batches(
+            exp_row.id, executions_root,
+        )
+        execution_id = planned[0].execution_id
+
+    result = runner.invoke(app, [
+        "experiment", "execute-batch", str(db_path),
+        "--execution-id", str(execution_id),
+        "--spec-file", str(spec_file),
+        "--spec", "my_spec",
+    ])
+    assert result.exit_code == 0, result.output
+    assert "completed" in result.output.lower()
+
+
+def test_execute_batch_nonexistent_execution_fails(tmp_path: Path):
+    db_path = tmp_path / "eb_fail.sqlite"
+    executions_root = tmp_path / "executions"
+    spec_file = _write_spec_file(tmp_path, db_path, executions_root)
+
+    # Sync experiment so the DB exists
+    plan_result = runner.invoke(app, ["experiment", "plan", str(spec_file)])
+    assert plan_result.exit_code == 0, plan_result.output
+
+    result = runner.invoke(app, [
+        "experiment", "execute-batch", str(db_path),
+        "--execution-id", "99999",
+        "--spec-file", str(spec_file),
+        "--spec", "my_spec",
+    ])
+    assert result.exit_code == 1
+    assert "not found" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# Submit CLI (dry-run)
+# ---------------------------------------------------------------------------
+
+
+def test_submit_dry_run(tmp_path: Path):
+    db_path = tmp_path / "submit.sqlite"
+    executions_root = tmp_path / "executions"
+    spec_file = _write_spec_file(tmp_path, db_path, executions_root)
+    script_path = tmp_path / "slurm_submit.sh"
+
+    result = runner.invoke(app, [
+        "experiment", "submit", str(spec_file),
+        "--dry-run",
+        "--script-path", str(script_path),
+    ])
+    assert result.exit_code == 0, result.output
+    assert "dry-run" in result.output.lower()
+    assert script_path.exists()

--- a/tests/medium/test_experiment_cli.py
+++ b/tests/medium/test_experiment_cli.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from experiment_definition.db import DatabaseManager
+from research_cli.main import app
+
+runner = CliRunner()
+
+
+def test_experiment_list_empty_db(tmp_path: Path):
+    db_path = tmp_path / "test.sqlite"
+    with DatabaseManager(db_path) as db:
+        db.initialize()
+
+    result = runner.invoke(app, ["experiment", "list", str(db_path)])
+    assert result.exit_code == 0
+    assert "Name" in result.output
+    assert "Description" in result.output
+
+
+def test_experiment_list_with_experiments(tmp_path: Path):
+    db_path = tmp_path / "test.sqlite"
+    with DatabaseManager(db_path) as db:
+        db.initialize()
+        db.add_experiment("my-experiment", "Test experiment")
+        db.add_experiment("another-exp", "Another one")
+
+    result = runner.invoke(app, ["experiment", "list", str(db_path)])
+    assert result.exit_code == 0
+    assert "my-experiment" in result.output
+    assert "another-exp" in result.output
+    assert "Test experiment" in result.output
+
+
+def test_experiment_status_shows_run_counts(tmp_path: Path):
+    db_path = tmp_path / "test.sqlite"
+    with DatabaseManager(db_path) as db:
+        db.initialize()
+        exp_id = db.add_experiment("status-exp", "For status test")
+        comp_id = db.add_component("test-algo", "ALGO")
+        ver_id = db.add_component_version(comp_id, "abc123")
+        env_id = db.add_component("test-env", "ENV")
+        env_ver_id = db.add_component_version(env_id, "def456")
+        hyper_id = db.add_hyperparam_config({"lr": 0.01})
+        db.add_run(exp_id, ver_id, env_ver_id, hyper_id, seed=0)
+        db.add_run(exp_id, ver_id, env_ver_id, hyper_id, seed=1)
+
+    result = runner.invoke(app, ["experiment", "status", str(db_path)])
+    assert result.exit_code == 0
+    assert "status-exp" in result.output
+    assert "2 runs" in result.output
+    assert "0 completed" in result.output
+    assert "2 pending" in result.output
+
+
+def _write_spec_file(tmp_path: Path, db_path: Path, executions_root: Path) -> Path:
+    spec_file = tmp_path / "test_spec.py"
+    spec_file.write_text(
+        textwrap.dedent(f"""\
+            from __future__ import annotations
+            from pathlib import Path
+            from research_runner.types import ExperimentSpec, ExecutionContext, ExecutionResult
+            from experiment_definition.experiment import Experiment
+            from experiment_definition.component import Component, ComponentType
+
+            def my_spec() -> ExperimentSpec:
+                experiment = Experiment("test-experiment", description="Test")
+                with experiment.for_component(Component(name="test-algo", path=Path("algo.py"), type=ComponentType.ALGO)):
+                    experiment.add_parameter("learning_rate", [0.01])
+                with experiment.for_component(Component(name="test-env", path=Path("env.py"), type=ComponentType.ENV)):
+                    pass
+                experiment.add_parameter("seed", [0])
+
+                def train(ctx: ExecutionContext) -> ExecutionResult:
+                    return ExecutionResult(metadata={{"trained": True}})
+
+                return ExperimentSpec(
+                    experiment=experiment,
+                    train_fn=train,
+                    db_path=Path("{db_path}"),
+                    executions_root=Path("{executions_root}"),
+                    capture_git=False,
+                )
+
+            def not_a_spec():
+                return "I am not a spec"
+        """),
+    )
+    return spec_file
+
+
+def test_experiment_plan_with_spec(tmp_path: Path):
+    db_path = tmp_path / "plan.sqlite"
+    executions_root = tmp_path / "executions"
+
+    spec_file = _write_spec_file(tmp_path, db_path, executions_root)
+
+    result = runner.invoke(app, ["experiment", "plan", str(spec_file)])
+    assert result.exit_code == 0, result.output
+    assert "my_spec" in result.output
+    assert "batch" in result.output.lower()
+
+
+def test_experiment_run_with_spec(tmp_path: Path):
+    db_path = tmp_path / "run.sqlite"
+    executions_root = tmp_path / "executions"
+
+    spec_file = _write_spec_file(tmp_path, db_path, executions_root)
+
+    result = runner.invoke(app, ["experiment", "run", str(spec_file)])
+    assert result.exit_code == 0, result.output
+    assert "my_spec" in result.output
+    assert "completed" in result.output.lower()
+
+
+def test_experiment_run_with_spec_filter(tmp_path: Path):
+    db_path = tmp_path / "run_filtered.sqlite"
+    executions_root = tmp_path / "executions"
+
+    spec_file = _write_spec_file(tmp_path, db_path, executions_root)
+
+    result = runner.invoke(app, ["experiment", "run", str(spec_file), "--spec", "my_spec"])
+    assert result.exit_code == 0, result.output
+    assert "my_spec" in result.output
+
+
+def test_spec_discovery_ignores_non_spec_functions(tmp_path: Path):
+    db_path = tmp_path / "disc.sqlite"
+    executions_root = tmp_path / "executions"
+
+    spec_file = _write_spec_file(tmp_path, db_path, executions_root)
+    module = __import__("importlib").util
+    loader_spec = module.spec_from_file_location("test_disc", spec_file)
+    loaded = module.module_from_spec(loader_spec)
+    loader_spec.loader.exec_module(loaded)
+
+    from research_cli.experiment import _discover_specs
+
+    specs = _discover_specs(loaded, None)
+    assert "my_spec" in specs
+    assert "not_a_spec" not in specs

--- a/tests/medium/test_experiment_db.py
+++ b/tests/medium/test_experiment_db.py
@@ -648,3 +648,137 @@ def test_context_manager_opens_and_closes() -> None:
         assert db.conn is not None
     # After __exit__, conn should be None
     assert db._conn is None  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# Invalidation
+# ---------------------------------------------------------------------------
+
+
+def test_invalidate_execution_sets_status(populated_db: DatabaseManager) -> None:
+    db = populated_db
+    algo_ver = db.get_latest_version(db.get_component("PPO3").id)  # type: ignore[union-attr]
+    env_ver = db.get_latest_version(db.get_component("CartPole2").id)  # type: ignore[union-attr]
+    hyper_id = db.add_hyperparam_config({"lr": 1e-3})
+    exp_id = db.get_experiment("Test Exp").id  # type: ignore[union-attr]
+    run_id = db.add_run(exp_id, algo_ver.id, env_ver.id, hyper_id, seed=20)  # type: ignore[union-attr]
+
+    execution_id = db.add_execution(hostname="node-inv")
+    db.link_execution_run(execution_id, run_id)
+    db.update_execution_status(execution_id, "COMPLETED")
+
+    result = db.invalidate_execution(execution_id)
+
+    assert result is True
+    assert db.get_execution(execution_id).status == "INVALID"  # type: ignore[union-attr]
+
+
+def test_invalidate_execution_nonexistent_returns_false(db: DatabaseManager) -> None:
+    assert db.invalidate_execution(999999) is False
+
+
+def test_invalidate_execution_makes_runs_unsatisfied(populated_db: DatabaseManager) -> None:
+    db = populated_db
+    algo_ver = db.get_latest_version(db.get_component("PPO3").id)  # type: ignore[union-attr]
+    env_ver = db.get_latest_version(db.get_component("CartPole2").id)  # type: ignore[union-attr]
+    hyper_id = db.add_hyperparam_config({"lr": 1e-3})
+    exp_id = db.get_experiment("Test Exp").id  # type: ignore[union-attr]
+    run_id = db.add_run(exp_id, algo_ver.id, env_ver.id, hyper_id, seed=21)  # type: ignore[union-attr]
+
+    execution_id = db.add_execution(hostname="node-inv2")
+    db.link_execution_run(execution_id, run_id)
+    db.update_execution_status(execution_id, "COMPLETED")
+
+    assert run_id not in [r.id for r in db.list_unsatisfied_runs(exp_id)]
+
+    db.invalidate_execution(execution_id)
+
+    assert run_id in [r.id for r in db.list_unsatisfied_runs(exp_id)]
+
+
+def test_invalidate_executions_by_commit(db: DatabaseManager) -> None:
+    e1 = db.add_execution(hostname="n1", git_commit="aaa111")
+    db.update_execution_status(e1, "COMPLETED")
+    e2 = db.add_execution(hostname="n2", git_commit="aaa111")
+    db.update_execution_status(e2, "COMPLETED")
+    e3 = db.add_execution(hostname="n3", git_commit="bbb222")
+    db.update_execution_status(e3, "COMPLETED")
+
+    invalidated = db.invalidate_executions_by_commit("aaa111")
+
+    assert sorted(invalidated) == sorted([e1, e2])
+    assert db.get_execution(e1).status == "INVALID"  # type: ignore[union-attr]
+    assert db.get_execution(e2).status == "INVALID"  # type: ignore[union-attr]
+    assert db.get_execution(e3).status == "COMPLETED"  # type: ignore[union-attr]
+
+
+def test_invalidate_by_commit_skips_pending_and_running(db: DatabaseManager) -> None:
+    e_pending = db.add_execution(hostname="n1", git_commit="ccc333")
+    e_running = db.add_execution(hostname="n2", git_commit="ccc333")
+    db.update_execution_status(e_running, "RUNNING")
+    e_completed = db.add_execution(hostname="n3", git_commit="ccc333")
+    db.update_execution_status(e_completed, "COMPLETED")
+
+    invalidated = db.invalidate_executions_by_commit("ccc333")
+
+    assert invalidated == [e_completed]
+    assert db.get_execution(e_pending).status == "PENDING"  # type: ignore[union-attr]
+    assert db.get_execution(e_running).status == "RUNNING"  # type: ignore[union-attr]
+    assert db.get_execution(e_completed).status == "INVALID"  # type: ignore[union-attr]
+
+
+# ---------------------------------------------------------------------------
+# list_executions
+# ---------------------------------------------------------------------------
+
+
+def test_list_executions_unfiltered(db: DatabaseManager) -> None:
+    db.add_execution(hostname="n1")
+    db.add_execution(hostname="n2")
+
+    rows = db.list_executions()
+
+    assert len(rows) == 2
+
+
+def test_list_executions_filter_by_status(db: DatabaseManager) -> None:
+    e1 = db.add_execution(hostname="n1")
+    e2 = db.add_execution(hostname="n2")
+    db.update_execution_status(e2, "COMPLETED")
+
+    rows = db.list_executions(status="COMPLETED")
+
+    assert len(rows) == 1
+    assert rows[0].id == e2
+
+
+def test_list_executions_filter_by_experiment(populated_db: DatabaseManager) -> None:
+    db = populated_db
+    algo_ver = db.get_latest_version(db.get_component("PPO3").id)  # type: ignore[union-attr]
+    env_ver = db.get_latest_version(db.get_component("CartPole2").id)  # type: ignore[union-attr]
+    hyper_id = db.add_hyperparam_config({"lr": 1e-3})
+    exp1_id = db.get_experiment("Test Exp").id  # type: ignore[union-attr]
+    exp2_id = db.add_experiment("Other Exp")
+
+    run1 = db.add_run(exp1_id, algo_ver.id, env_ver.id, hyper_id, seed=30)  # type: ignore[union-attr]
+    run2 = db.add_run(exp2_id, algo_ver.id, env_ver.id, hyper_id, seed=31)  # type: ignore[union-attr]
+
+    exec1 = db.add_execution(hostname="n1")
+    db.link_execution_run(exec1, run1)
+    exec2 = db.add_execution(hostname="n2")
+    db.link_execution_run(exec2, run2)
+
+    rows = db.list_executions(exp1_id)
+
+    assert len(rows) == 1
+    assert rows[0].id == exec1
+
+
+def test_list_executions_filter_by_git_commit(db: DatabaseManager) -> None:
+    db.add_execution(hostname="n1", git_commit="ccc333")
+    db.add_execution(hostname="n2", git_commit="ddd444")
+
+    rows = db.list_executions(git_commit="ccc333")
+
+    assert len(rows) == 1
+    assert rows[0].git_commit == "ccc333"

--- a/tests/medium/test_research_cluster.py
+++ b/tests/medium/test_research_cluster.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from research_cluster.config import SlurmConfig
+from research_cluster.script import build_job_script, build_sbatch_flags, write_job_script
+from research_cluster.submit import submit_experiment
+
+
+def test_slurm_config_defaults():
+    config = SlurmConfig()
+    assert config.account is None
+    assert config.partition is None
+    assert config.time == "2:59:00"
+    assert config.cpus_per_task == 1
+    assert config.mem_per_cpu == "4G"
+    assert config.gpus_per_task is None
+    assert config.modules == []
+    assert config.setup_commands == []
+    assert config.log_path == "slurm-%A_%a.out"
+
+
+def test_slurm_config_from_dict():
+    config = SlurmConfig.from_dict({
+        "account": "test-acct",
+        "partition": "gpu",
+        "time": "4:00:00",
+        "gpus_per_task": 1,
+    })
+    assert config.account == "test-acct"
+    assert config.partition == "gpu"
+    assert config.time == "4:00:00"
+    assert config.gpus_per_task == 1
+    assert config.cpus_per_task == 1
+    assert config.mem_per_cpu == "4G"
+
+
+def test_slurm_config_from_json(tmp_path: Path):
+    json_file = tmp_path / "slurm.json"
+    json_file.write_text(json.dumps({
+        "account": "json-acct",
+        "partition": "batch",
+        "time": "8:00:00",
+        "cpus_per_task": 4,
+    }))
+    config = SlurmConfig.from_json(str(json_file))
+    assert config.account == "json-acct"
+    assert config.partition == "batch"
+    assert config.time == "8:00:00"
+    assert config.cpus_per_task == 4
+
+
+def test_build_sbatch_flags_minimal():
+    config = SlurmConfig()
+    flags = build_sbatch_flags(config)
+    assert "--time=2:59:00" in flags
+    assert "--cpus-per-task=1" in flags
+    assert "--mem-per-cpu=4G" in flags
+    assert "--account" not in flags
+    assert "--gpus-per-task" not in flags
+
+
+def test_build_sbatch_flags_with_gpu_and_account():
+    config = SlurmConfig(account="my-acct", gpus_per_task=2)
+    flags = build_sbatch_flags(config)
+    assert "--account=my-acct" in flags
+    assert "--gpus-per-task=2" in flags
+
+
+def test_build_job_script_contains_essentials():
+    config = SlurmConfig()
+    script = build_job_script(
+        config,
+        execution_ids=[1, 2, 3],
+        db_path=Path("/data/exp.sqlite"),
+        spec_file=Path("/specs/train.py"),
+        spec_name="my_spec",
+    )
+    assert script.startswith("#!/bin/bash")
+    assert "#SBATCH --array=0-2" in script
+    assert "EXECUTION_IDS=(1 2 3)" in script
+    assert "execute-batch" in script
+    assert "/specs/train.py" in script
+    assert "my_spec" in script
+
+
+def test_build_job_script_with_modules():
+    config = SlurmConfig(modules=["python/3.13", "cuda/12"])
+    script = build_job_script(
+        config,
+        execution_ids=[1],
+        db_path=Path("/data/exp.sqlite"),
+        spec_file=Path("/specs/train.py"),
+        spec_name="s",
+    )
+    assert "module load python/3.13" in script
+    assert "module load cuda/12" in script
+
+
+def test_build_job_script_empty_ids_raises():
+    config = SlurmConfig()
+    with pytest.raises(ValueError, match="must not be empty"):
+        build_job_script(
+            config,
+            execution_ids=[],
+            db_path=Path("/data/exp.sqlite"),
+            spec_file=Path("/specs/train.py"),
+            spec_name="s",
+        )
+
+
+def test_write_job_script_creates_file(tmp_path: Path):
+    script = "#!/bin/bash\necho hello"
+    out = tmp_path / "sub" / "job.sh"
+    write_job_script(script, out)
+    assert out.exists()
+    assert out.read_text().startswith("#!/bin/bash")
+
+
+def test_submit_experiment_dry_run(tmp_path: Path):
+    config = SlurmConfig()
+    script_path = tmp_path / "slurm_submit.sh"
+    result = submit_experiment(
+        config,
+        execution_ids=[10, 20],
+        db_path=Path("/data/exp.sqlite"),
+        spec_file=Path("/specs/train.py"),
+        spec_name="my_spec",
+        script_path=script_path,
+        dry_run=True,
+    )
+    assert result is None
+    assert script_path.exists()
+    assert "#!/bin/bash" in script_path.read_text()

--- a/uv.lock
+++ b/uv.lock
@@ -1418,14 +1418,18 @@ version = "0.1.0"
 source = { editable = "cli" }
 dependencies = [
     { name = "copier" },
+    { name = "experiment-definition" },
     { name = "pyyaml" },
+    { name = "research-runner" },
     { name = "typer" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "copier", specifier = "~=9.4" },
+    { name = "experiment-definition", editable = "libs/experiment-definition" },
     { name = "pyyaml", specifier = "~=6.0" },
+    { name = "research-runner", editable = "libs/research-runner" },
     { name = "typer", specifier = "~=0.12" },
 ]
 
@@ -1461,6 +1465,7 @@ dependencies = [
     { name = "research-analysis" },
     { name = "research-cli" },
     { name = "research-instrument" },
+    { name = "research-runner" },
     { name = "research-store" },
     { name = "rl-agents" },
     { name = "rl-components" },
@@ -1502,6 +1507,7 @@ requires-dist = [
     { name = "research-analysis", editable = "libs/research-analysis" },
     { name = "research-cli", editable = "cli" },
     { name = "research-instrument", editable = "libs/research-instrument" },
+    { name = "research-runner", editable = "libs/research-runner" },
     { name = "research-store", editable = "libs/research-store" },
     { name = "rl-agents", editable = "libs/rl-agents" },
     { name = "rl-components", editable = "libs/rl-components" },
@@ -1609,6 +1615,7 @@ dependencies = [
     { name = "distrax" },
     { name = "flax" },
     { name = "jax" },
+    { name = "jax-nn" },
     { name = "jaxatari" },
 ]
 
@@ -1619,6 +1626,7 @@ requires-dist = [
     { name = "distrax", specifier = ">=0.1.8" },
     { name = "flax", specifier = "~=0.12" },
     { name = "jax", specifier = "~=0.9" },
+    { name = "jax-nn", editable = "libs/jax-nn" },
     { name = "jaxatari", git = "https://github.com/k4ntz/JAXAtari?rev=v0.1" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -480,6 +480,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/73/fda6a25f3beeb5e49d74330b44092b9e5a547395ccd478d1103ddcbff1fc/gymnasium-1.3.0-py3-none-any.whl", hash = "sha256:6b8c159a8540dcbcb221722d7efda24d78ebbcbc3bd2ea1c2611aa2a34471fc2", size = 953904, upload-time = "2026-04-22T13:47:12.13Z" },
 ]
 
+[package.optional-dependencies]
+atari = [
+    { name = "ale-py" },
+]
+
 [[package]]
 name = "gymnax"
 version = "0.0.9"
@@ -582,26 +587,6 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [{ name = "jax", specifier = "~=0.9" }]
-
-[[package]]
-name = "jaxatari"
-version = "0.1.0"
-source = { git = "https://github.com/k4ntz/JAXAtari?rev=v0.1#8207fa1a9da9e974caf224f1daa6c8d11794019c" }
-dependencies = [
-    { name = "absl-py" },
-    { name = "ale-py" },
-    { name = "chex" },
-    { name = "flax" },
-    { name = "gymnasium" },
-    { name = "gymnax" },
-    { name = "jax" },
-    { name = "ml-dtypes" },
-    { name = "numpy" },
-    { name = "opt-einsum" },
-    { name = "scipy" },
-    { name = "toolz" },
-    { name = "typing-extensions" },
-]
 
 [[package]]
 name = "jaxlib"
@@ -1420,6 +1405,7 @@ dependencies = [
     { name = "copier" },
     { name = "experiment-definition" },
     { name = "pyyaml" },
+    { name = "research-cluster" },
     { name = "research-runner" },
     { name = "typer" },
 ]
@@ -1429,6 +1415,7 @@ requires-dist = [
     { name = "copier", specifier = "~=9.4" },
     { name = "experiment-definition", editable = "libs/experiment-definition" },
     { name = "pyyaml", specifier = "~=6.0" },
+    { name = "research-cluster", editable = "libs/research-cluster" },
     { name = "research-runner", editable = "libs/research-runner" },
     { name = "typer", specifier = "~=0.12" },
 ]
@@ -1436,7 +1423,13 @@ requires-dist = [
 [[package]]
 name = "research-cluster"
 version = "0.1.0"
-source = { virtual = "libs/research-cluster" }
+source = { editable = "libs/research-cluster" }
+dependencies = [
+    { name = "experiment-definition" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "experiment-definition", editable = "libs/experiment-definition" }]
 
 [[package]]
 name = "research-core"
@@ -1453,7 +1446,6 @@ dependencies = [
     { name = "jax-nn" },
     { name = "jax-replay" },
     { name = "jax-utils" },
-    { name = "jaxatari" },
     { name = "jaxlib" },
     { name = "jaxtyping" },
     { name = "matplotlib" },
@@ -1495,7 +1487,6 @@ requires-dist = [
     { name = "jax-nn", editable = "libs/jax-nn" },
     { name = "jax-replay", editable = "libs/jax-replay" },
     { name = "jax-utils", editable = "libs/jax-utils" },
-    { name = "jaxatari", git = "https://github.com/k4ntz/JAXAtari?rev=v0.1" },
     { name = "jaxlib", specifier = "~=0.9" },
     { name = "jaxtyping", specifier = "~=0.3" },
     { name = "matplotlib", specifier = ">=3.9" },
@@ -1610,24 +1601,24 @@ name = "rl-components"
 version = "0.1.0"
 source = { editable = "libs/rl-components" }
 dependencies = [
+    { name = "ale-py" },
     { name = "brax" },
     { name = "chex" },
     { name = "distrax" },
     { name = "flax" },
+    { name = "gymnasium", extra = ["atari"] },
     { name = "jax" },
-    { name = "jax-nn" },
-    { name = "jaxatari" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "ale-py", specifier = ">=0.10" },
     { name = "brax", specifier = "~=0.14" },
     { name = "chex", specifier = "~=0.1" },
     { name = "distrax", specifier = ">=0.1.8" },
     { name = "flax", specifier = "~=0.12" },
+    { name = "gymnasium", extras = ["atari"], specifier = ">=1.0" },
     { name = "jax", specifier = "~=0.9" },
-    { name = "jax-nn", editable = "libs/jax-nn" },
-    { name = "jaxatari", git = "https://github.com/k4ntz/JAXAtari?rev=v0.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a `research experiment` sub-app to the CLI with four commands for managing experiments through the database-centric orchestration model (ADR-007).

Stacked on #65 (research-runner library).

## Commands

### `research experiment list <db_path>`
Lists all experiments in a database with names and descriptions.

### `research experiment status <db_path> [--experiment SLUG]`
Shows run counts by status (completed/pending) for each experiment.

### `research experiment plan <spec_file> [--spec NAME] [--db PATH]`
Dry-run: syncs an experiment definition to the database and shows planned batches without executing.

### `research experiment run <spec_file> [--spec NAME] [--db PATH] [--executions-root PATH] [--max-runs N]`
Runs experiments by discovering spec factories from a Python file. Spec files are regular Python files containing functions annotated with `-> ExperimentSpec`. All matching specs run by default; use `--spec` to filter.

## Spec Discovery

The CLI discovers experiment specs by scanning a Python file for functions with a return type annotation of `ExperimentSpec`. This uses file paths (not import paths) for natural shell tab-completion:

```bash
research experiment run missingness_rl/declarative.py
research experiment run missingness_rl/declarative.py --spec online_shift_spec
```

## New Type: ExperimentSpec

Added to `research-runner/types.py` — bundles experiment definition, training callback, paths, and runner options into a single frozen dataclass.

## Tests

7 tests covering: list (empty/populated), status with run counts, plan with spec file, run with spec file, spec filtering, and spec discovery (ignores non-spec functions).