### PR TITLE
refactor: replace TYPE_CHECKING apply stubs with TypedApply generic mixin

### DIFF
--- a/libs/jax-nn/src/jax_nn/heads.py
+++ b/libs/jax-nn/src/jax_nn/heads.py
@@ -2,17 +2,16 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import flax.linen as nn
 import jax
 import jax.numpy as jnp
 from jax import Array
 
 from jax_nn.initializers import output_orthogonal, stable_orthogonal
+from jax_nn.typed_module import TypedApply
 
 
-class DuelingHead(nn.Module):
+class DuelingHead(TypedApply[Array], nn.Module):
     """Dueling network head (Wang et al., 2016).
 
     Separates state-value and advantage streams:
@@ -33,15 +32,6 @@ class DuelingHead(nn.Module):
     action_dim: int
     hidden_features: int = 512
     dtype: jnp.dtype = jnp.float32
-
-    if TYPE_CHECKING:
-        def apply(
-            self,
-            variables: object,
-            x: Array,
-            *,
-            rngs: object | None = None,
-        ) -> Array: ...
 
     @nn.compact
     def __call__(self, x: Array) -> Array:

--- a/libs/jax-nn/src/jax_nn/layers.py
+++ b/libs/jax-nn/src/jax_nn/layers.py
@@ -2,17 +2,16 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import flax.linen as nn
 import jax
 import jax.numpy as jnp
 from jax import Array
 
 from jax_nn.initializers import legacy_dqn_uniform
+from jax_nn.typed_module import TypedApply
 
 
-class NatureCNN(nn.Module):
+class NatureCNN(TypedApply[Array], nn.Module):
     """Canonical Atari convolutional torso from the DQN Nature paper.
 
     Expects channel-last image observations and applies the standard three-layer
@@ -31,15 +30,6 @@ class NatureCNN(nn.Module):
     """
 
     dtype: jnp.dtype = jnp.float32
-
-    if TYPE_CHECKING:
-        def apply(
-            self,
-            variables: object,
-            x: Array,
-            *,
-            rngs: object | None = None,
-        ) -> Array: ...
 
     @nn.compact
     def __call__(self, x: Array) -> Array:
@@ -70,7 +60,7 @@ class NatureCNN(nn.Module):
         return x.reshape(x.shape[:-3] + (-1,))
 
 
-class NoisyLinear(nn.Module):
+class NoisyLinear(TypedApply[Array], nn.Module):
     """Noisy linear layer with factored Gaussian noise (Fortunato et al., 2017).
 
     Implements:
@@ -99,15 +89,6 @@ class NoisyLinear(nn.Module):
     features: int
     sigma_init: float = 0.5
     dtype: jnp.dtype = jnp.float32
-
-    if TYPE_CHECKING:
-        def apply(
-            self,
-            variables: object,
-            x: Array,
-            *,
-            rngs: object | None = None,
-        ) -> Array: ...
 
     @nn.compact
     def __call__(self, x: Array) -> Array:

--- a/libs/jax-nn/src/jax_nn/typed_module.py
+++ b/libs/jax-nn/src/jax_nn/typed_module.py
@@ -1,0 +1,33 @@
+"""Type-safe apply() mixin for flax nn.Module subclasses."""
+
+from __future__ import annotations
+
+from typing import Generic, TypeVar
+
+import jax
+
+T_co = TypeVar("T_co", covariant=True)
+
+
+class TypedApply(Generic[T_co]):
+    """Generic mixin providing a typed apply() signature for flax nn.Module subclasses.
+
+    Eliminates the ``if TYPE_CHECKING: def apply(...)`` pattern.
+
+    Usage (always put TypedApply before nn.Module in the bases)::
+
+        class MyNet(TypedApply[jax.Array], nn.Module):
+            ...
+
+    At runtime, the MRO calls this apply() which delegates to nn.Module.apply().
+    For type checkers, the return type T_co is inferred from the generic parameter.
+    """
+
+    def apply(
+        self,
+        variables: object,
+        x: jax.Array,
+        *,
+        rngs: object | None = None,
+    ) -> T_co:
+        return super().apply(variables, x, rngs=rngs)  # type: ignore[return-value]

--- a/libs/rl-agents/src/rl_agents/dqn.py
+++ b/libs/rl-agents/src/rl_agents/dqn.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Literal, Protocol, cast
+from typing import Literal, Protocol, cast
 
 import flax.linen as nn
 import jax
@@ -7,6 +7,7 @@ import optax
 from flax.training.train_state import TrainState
 from jax_nn.initializers import legacy_dqn_uniform
 from jax_nn.layers import NatureCNN
+from jax_nn.typed_module import TypedApply
 from rl_components.buffers import ReplayBuffer
 from rl_components.structs import chex_struct
 
@@ -30,17 +31,8 @@ class DQNConfig:
     NETWORK_PRESET: Literal["mlp", "nature_cnn"] = "mlp"
 
 
-class QNetwork(nn.Module):
+class QNetwork(TypedApply[jax.Array], nn.Module):
     action_dim: int
-
-    if TYPE_CHECKING:
-        def apply(
-            self,
-            variables: object,
-            x: jax.Array,
-            *,
-            rngs: object | None = None,
-        ) -> jax.Array: ...
 
     @nn.compact
     def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
@@ -82,18 +74,9 @@ class _HasNetworkPreset(Protocol):
     def NETWORK_PRESET(self) -> Literal["mlp", "nature_cnn"]: ...
 
 
-class NatureQNetwork(nn.Module):
+class NatureQNetwork(TypedApply[jax.Array], nn.Module):
     action_dim: int
     observation_layout: Literal["hwc", "fhwc"]
-
-    if TYPE_CHECKING:
-        def apply(
-            self,
-            variables: object,
-            x: jax.Array,
-            *,
-            rngs: object | None = None,
-        ) -> jax.Array: ...
 
     @nn.compact
     def __call__(self, x: jnp.ndarray) -> jnp.ndarray:

--- a/libs/rl-agents/src/rl_agents/dueling_dqn.py
+++ b/libs/rl-agents/src/rl_agents/dueling_dqn.py
@@ -9,7 +9,7 @@ This decomposition helps the agent learn which states are valuable
 without having to learn the effect of each action at every state.
 """
 
-from typing import TYPE_CHECKING, Literal, cast
+from typing import Literal, cast
 
 import flax.linen as nn
 import jax
@@ -18,6 +18,7 @@ import optax
 from flax.training.train_state import TrainState
 from jax_nn.heads import DuelingHead
 from jax_nn.initializers import stable_orthogonal
+from jax_nn.typed_module import TypedApply
 from rl_components.buffers import ReplayBuffer
 from rl_components.structs import chex_struct
 
@@ -43,7 +44,7 @@ class DuelingDQNConfig:
     NETWORK_PRESET: Literal["mlp", "nature_cnn"] = "mlp"
 
 
-class DuelingQNetwork(nn.Module):
+class DuelingQNetwork(TypedApply[jax.Array], nn.Module):
     """Q-network with a dueling architecture.
 
     A shared feature extractor feeds into a DuelingHead that
@@ -51,15 +52,6 @@ class DuelingQNetwork(nn.Module):
     """
 
     action_dim: int
-
-    if TYPE_CHECKING:
-        def apply(
-            self,
-            variables: object,
-            x: jax.Array,
-            *,
-            rngs: object | None = None,
-        ) -> jax.Array: ...
 
     @nn.compact
     def __call__(self, x: jnp.ndarray) -> jnp.ndarray:

--- a/libs/rl-agents/src/rl_agents/rainbow.py
+++ b/libs/rl-agents/src/rl_agents/rainbow.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Literal, NamedTuple, cast
+from typing import Literal, NamedTuple, cast
 
 import flax.linen as nn
 import jax
@@ -11,6 +11,7 @@ from jax_nn.distributional import (
     categorical_l2_project,
 )
 from jax_nn.layers import NatureCNN, NoisyLinear
+from jax_nn.typed_module import TypedApply
 from jax_replay.per import init_per_buffer, per_add, per_sample, per_update_priorities
 from jax_replay.types import PERBufferState
 from rl_components.structs import chex_struct
@@ -59,20 +60,11 @@ class _NStepAccumulatorState:
     size: jax.Array
 
 
-class RainbowNatureNetwork(nn.Module):
+class RainbowNatureNetwork(TypedApply[jax.Array], nn.Module):
     action_dim: int
     num_atoms: int
     observation_layout: Literal["hwc", "fhwc"]
     dtype: jnp.dtype = jnp.float32
-
-    if TYPE_CHECKING:
-        def apply(
-            self,
-            variables: object,
-            x: jax.Array,
-            *,
-            rngs: object | None = None,
-        ) -> jax.Array: ...
 
     @nn.compact
     def __call__(self, x: jax.Array) -> jax.Array:

--- a/libs/rl-components/pyproject.toml
+++ b/libs/rl-components/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "chex~=0.1",
     "distrax>=0.1.8",
     "flax~=0.12",
+    "jax-nn",
     "jaxatari @ git+https://github.com/k4ntz/JAXAtari@v0.1",
     "jax~=0.9",
 ]
@@ -18,3 +19,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.uv.sources]
+jax-nn = { workspace = true }

--- a/libs/rl-components/src/rl_components/networks.py
+++ b/libs/rl-components/src/rl_components/networks.py
@@ -1,9 +1,10 @@
-from typing import TYPE_CHECKING, cast
+from typing import cast
 
 import distrax
 import flax.linen as nn
 import jax
 import jax.numpy as jnp
+from jax_nn.typed_module import TypedApply
 
 from rl_components.structs import chex_struct
 
@@ -37,18 +38,9 @@ class TanhNormalDiag:
         return cast(jax.Array, self._base_distribution().entropy())
 
 
-class ActorCritic(nn.Module):
+class ActorCritic(TypedApply[tuple[distrax.Categorical, jax.Array]], nn.Module):
     action_dim: int
     activation: str = "tanh"
-
-    if TYPE_CHECKING:
-        def apply(
-            self,
-            variables: object,
-            x: jax.Array,
-            *,
-            rngs: object | None = None,
-        ) -> tuple[distrax.Categorical, jax.Array]: ...
 
     @nn.compact
     def __call__(self, x: jnp.ndarray) -> tuple[distrax.Categorical, jnp.ndarray]:
@@ -71,20 +63,11 @@ class ActorCritic(nn.Module):
         return probs, jnp.squeeze(critic_value, axis=-1)
 
 
-class ContinuousActorCritic(nn.Module):
+class ContinuousActorCritic(TypedApply[tuple[TanhNormalDiag, jax.Array]], nn.Module):
     action_dim: int
     activation: str = "tanh"
     log_std_min: float = -20.0
     log_std_max: float = 2.0
-
-    if TYPE_CHECKING:
-        def apply(
-            self,
-            variables: object,
-            x: jax.Array,
-            *,
-            rngs: object | None = None,
-        ) -> tuple[TanhNormalDiag, jax.Array]: ...
 
     @nn.compact
     def __call__(self, x: jnp.ndarray) -> tuple[TanhNormalDiag, jnp.ndarray]:


### PR DESCRIPTION
Replace the repetitive `if TYPE_CHECKING: def apply(...)` pattern across `jax-nn` and `rl-agents` modules with a `TypedApply[T]` generic mixin that provides type-safe `apply()` signatures at both runtime and type-check time.

### Changes
- **New**: `libs/jax-nn/src/jax_nn/typed_module.py` — `TypedApply[T_co]` mixin using `Generic[T_co]` with a typed `apply()` that delegates to `nn.Module.apply()`
- **Simplified**: `heads.py`, `layers.py`, `dqn.py`, `dueling_dqn.py`, `rainbow.py`, `networks.py` — replaced `if TYPE_CHECKING` stubs with `TypedApply[jax.Array]` in class bases
- **Updated**: `libs/rl-components/pyproject.toml` — added `jax-nn` dependency for the mixin import

Net result: **-98 lines**, **+56 lines** — removes boilerplate while preserving full type safety.