### PR TITLE
feat(#77): add GymnaxEnvAdapter with correct truncation/termination signals

### DIFF
--- a/libs/rl-components/src/rl_components/gymnax_adapter.py
+++ b/libs/rl-components/src/rl_components/gymnax_adapter.py
@@ -1,0 +1,126 @@
+"""Gymnax adapter: wraps native gymnax environments into EnvProtocol with correct trunc/term signals.
+
+Gymnax treats time-limit truncations as terminations (old OpenAI gym convention), which
+biases return estimates. This adapter intercepts truncation at ``max_steps`` by telling
+gymnax its limit is ``T + 1``, then checking ``state.time >= T`` itself and emitting
+proper separated ``terminated`` / ``truncated`` signals.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+import chex
+import jax
+import jax.numpy as jnp
+
+from rl_components.env_protocol import EnvReset, EnvSpec, EnvStep
+
+
+class _GymnaxEnv(Protocol):
+    name: str
+
+    @property
+    def default_params(self) -> Any: ...
+
+    def observation_space(self, params: Any) -> Any: ...
+
+    def action_space(self, params: Any) -> Any: ...
+
+    def reset_env(self, key: jax.Array, params: Any) -> tuple[jax.Array, Any]: ...
+
+    def step_env(
+        self,
+        key: jax.Array,
+        state: Any,
+        action: Any,
+        params: Any,
+    ) -> tuple[jax.Array, Any, jax.Array, jax.Array, dict[str, Any]]: ...
+
+
+class GymnaxEnvAdapter:
+    """Wraps a native gymnax ``Environment`` into ``EnvProtocol``.
+
+    Sets gymnax's ``max_steps_in_episode = max_steps + 1`` so its own time-limit
+    check cannot fire at step ``T``.  Calls ``step_env`` / ``reset_env`` directly
+    (bypassing gymnax's JIT-wrapped ``step``), checks truncation itself, and
+    handles auto-reset on any episode end.
+    """
+
+    def __init__(
+        self,
+        env: _GymnaxEnv,
+        max_steps: int | None = None,
+        default_params: Any = None,
+    ) -> None:
+        self._env = env
+        self._default_params = default_params if default_params is not None else env.default_params
+        self._max_steps: int = (
+            max_steps if max_steps is not None else int(self._default_params.max_steps_in_episode)
+        )
+
+    def _gymnax_params(self, params: Any) -> Any:
+        p = params if params is not None else self._default_params
+        return p.replace(max_steps_in_episode=self._max_steps + 1)
+
+    def spec(self, params: Any = None) -> EnvSpec:
+        gp = self._gymnax_params(params)
+        obs_space = self._env.observation_space(gp)
+        act_space = self._env.action_space(gp)
+        num_actions: int | None = getattr(act_space, "n", None)
+        return EnvSpec(
+            id=self._env.name,
+            observation_shape=tuple(obs_space.shape),
+            action_shape=() if num_actions is not None else tuple(act_space.shape),
+            observation_dtype=jnp.float32,
+            action_dtype=jnp.int32 if num_actions is not None else jnp.float32,
+            num_actions=num_actions,
+        )
+
+    def reset(self, key: chex.PRNGKey, params: Any = None) -> EnvReset[jax.Array, Any]:
+        gp = self._gymnax_params(params)
+        obs, state = self._env.reset_env(key, gp)
+        return EnvReset(observation=obs, state=state)
+
+    def step(
+        self,
+        key: chex.PRNGKey,
+        state: Any,
+        action: Any,
+        params: Any = None,
+    ) -> EnvStep[jax.Array, Any]:
+        gp = self._gymnax_params(params)
+        key_step, key_reset = jax.random.split(key)
+
+        obs_st, state_st, reward, done, info = self._env.step_env(key_step, state, action, gp)
+        obs_re, state_re = self._env.reset_env(key_reset, gp)
+
+        # state_st.time is already incremented by step_env.
+        # Since gymnax max_steps = T+1, done only fires for true env termination here.
+        truncated = jnp.asarray(state_st.time >= self._max_steps)
+        terminated = jnp.asarray(done)
+        episode_done = jnp.logical_or(terminated, truncated)
+
+        final_state = jax.tree.map(
+            lambda x, y: jax.lax.select(episode_done, x, y), state_re, state_st
+        )
+        final_obs = jax.lax.select(episode_done, obs_re, obs_st)
+
+        return EnvStep(
+            observation=final_obs,
+            state=final_state,
+            reward=jnp.asarray(reward),
+            terminated=terminated,
+            truncated=truncated,
+            info=dict(info),
+        )
+
+
+def make_gymnax_env(env_name: str, max_steps: int | None = None) -> GymnaxEnvAdapter:
+    """Create a ``GymnaxEnvAdapter`` from a registered gymnax environment name."""
+    import gymnax  # noqa: PLC0415
+
+    env, default_params = gymnax.make(env_name)
+    return GymnaxEnvAdapter(env, max_steps=max_steps, default_params=default_params)
+
+

--- a/tests/small/test_rl_components_gymnax_adapter.py
+++ b/tests/small/test_rl_components_gymnax_adapter.py
@@ -1,0 +1,207 @@
+"""Small tests for the gymnax → EnvProtocol adapter with correct trunc/term signals."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+from flax import struct
+from rl_components.gymnax_adapter import GymnaxEnvAdapter, make_gymnax_env
+
+# ---------------------------------------------------------------------------
+# Minimal fake gymnax environment
+# ---------------------------------------------------------------------------
+
+@struct.dataclass
+class FakeEnvState:
+    time: int
+
+
+@struct.dataclass
+class FakeEnvParams:
+    max_steps_in_episode: int = 10
+    terminate_at: int = 999  # step at which env sends done=True; 999 = never in tests
+
+
+class FakeGymnaxEnv:
+    """Gymnax-style env with controllable termination for deterministic tests."""
+
+    name = "fake"
+
+    @property
+    def default_params(self) -> FakeEnvParams:
+        return FakeEnvParams()
+
+    def observation_space(self, params: FakeEnvParams) -> Any:
+        from gymnax.environments import spaces
+        return spaces.Box(low=-1.0, high=1.0, shape=(2,), dtype=jnp.float32)
+
+    def action_space(self, params: FakeEnvParams) -> Any:
+        from gymnax.environments import spaces
+        return spaces.Discrete(2)
+
+    def reset_env(self, key: jax.Array, params: FakeEnvParams) -> tuple[jax.Array, FakeEnvState]:
+        del key
+        return jnp.zeros((2,), dtype=jnp.float32), FakeEnvState(time=0)  # type: ignore
+
+    def step_env(
+        self,
+        key: jax.Array,
+        state: FakeEnvState,
+        action: Any,
+        params: FakeEnvParams,
+    ) -> tuple[jax.Array, FakeEnvState, jax.Array, jax.Array, dict]:
+        del key, action
+        new_state = FakeEnvState(time=state.time + 1)  # type: ignore
+        obs = jnp.full((2,), new_state.time, dtype=jnp.float32)
+        reward = jnp.array(1.0)
+        done = jnp.array(new_state.time >= params.terminate_at)
+        return obs, new_state, reward, done, {}
+
+
+def _make_adapter(max_steps: int = 5, terminate_at: int = 999) -> GymnaxEnvAdapter:
+    env = FakeGymnaxEnv()
+    params = FakeEnvParams(max_steps_in_episode=max_steps + 1, terminate_at=terminate_at)  # type: ignore
+    return GymnaxEnvAdapter(env, max_steps=max_steps, default_params=params)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestGymnaxEnvAdapterSignals:
+    def test_normal_step_has_neither_signal(self) -> None:
+        adapter = _make_adapter(max_steps=5)
+        key = jax.random.key(0)
+        reset = adapter.reset(key)
+        step = adapter.step(key, reset.state, jnp.array(0))
+
+        assert not bool(step.terminated)
+        assert not bool(step.truncated)
+
+    def test_truncation_fires_at_max_steps(self) -> None:
+        adapter = _make_adapter(max_steps=3)
+        key = jax.random.key(0)
+        reset = adapter.reset(key)
+        state = reset.state
+
+        for _ in range(2):
+            result = adapter.step(key, state, jnp.array(0))
+            assert not bool(result.terminated)
+            assert not bool(result.truncated)
+            state = result.state
+
+        final = adapter.step(key, state, jnp.array(0))
+        assert not bool(final.terminated)
+        assert bool(final.truncated)
+
+    def test_termination_fires_before_max_steps(self) -> None:
+        adapter = _make_adapter(max_steps=10, terminate_at=2)
+        key = jax.random.key(0)
+        reset = adapter.reset(key)
+        state = reset.state
+
+        first = adapter.step(key, state, jnp.array(0))
+        assert not bool(first.terminated)
+        assert not bool(first.truncated)
+
+        second = adapter.step(key, first.state, jnp.array(0))
+        assert bool(second.terminated)
+        assert not bool(second.truncated)
+
+    def test_both_signals_false_mid_episode(self) -> None:
+        adapter = _make_adapter(max_steps=10, terminate_at=999)
+        key = jax.random.key(0)
+        reset = adapter.reset(key)
+        state = reset.state
+
+        for _ in range(5):
+            result = adapter.step(key, state, jnp.array(0))
+            assert not bool(result.terminated)
+            assert not bool(result.truncated)
+            state = result.state
+
+
+class TestGymnaxEnvAdapterAutoReset:
+    def test_state_resets_after_truncation(self) -> None:
+        adapter = _make_adapter(max_steps=3)
+        key = jax.random.key(0)
+        reset = adapter.reset(key)
+        state = reset.state
+
+        for _ in range(2):
+            state = adapter.step(key, state, jnp.array(0)).state
+
+        truncated_step = adapter.step(key, state, jnp.array(0))
+        assert bool(truncated_step.truncated)
+        # After auto-reset, time should be 0
+        assert int(truncated_step.state.time) == 0
+
+    def test_state_resets_after_termination(self) -> None:
+        adapter = _make_adapter(max_steps=10, terminate_at=2)
+        key = jax.random.key(0)
+        reset = adapter.reset(key)
+        state = adapter.step(key, reset.state, jnp.array(0)).state
+
+        terminal_step = adapter.step(key, state, jnp.array(0))
+        assert bool(terminal_step.terminated)
+        assert int(terminal_step.state.time) == 0
+
+    def test_observation_after_truncation_is_reset_obs(self) -> None:
+        adapter = _make_adapter(max_steps=3)
+        key = jax.random.key(0)
+        reset_obs = adapter.reset(key).observation
+        state = adapter.reset(key).state
+
+        for _ in range(2):
+            state = adapter.step(key, state, jnp.array(0)).state
+
+        truncated_step = adapter.step(key, state, jnp.array(0))
+        # After truncation the returned obs is the reset obs (all zeros for FakeGymnaxEnv)
+        assert bool(jnp.all(truncated_step.observation == reset_obs))
+
+
+class TestGymnaxEnvAdapterSpec:
+    def test_spec_discrete_action_space(self) -> None:
+        adapter = _make_adapter()
+        spec = adapter.spec()
+
+        assert spec.id == "fake"
+        assert spec.observation_shape == (2,)
+        assert spec.action_shape == ()
+        assert spec.num_actions == 2
+        assert spec.action_dtype == jnp.int32
+
+    def test_gymnax_max_steps_is_bumped_to_t_plus_one(self) -> None:
+        adapter = _make_adapter(max_steps=7)
+        gp = adapter._gymnax_params(None)
+        assert gp.max_steps_in_episode == 8
+
+
+class TestMakeGymnaxEnv:
+    def test_factory_creates_adapter(self) -> None:
+        adapter = make_gymnax_env("CartPole-v1")
+        assert isinstance(adapter, GymnaxEnvAdapter)
+
+    def test_factory_uses_env_default_max_steps_when_not_specified(self) -> None:
+        adapter = make_gymnax_env("CartPole-v1")
+        # CartPole-v1 default is 500
+        assert adapter._max_steps == 500
+
+    def test_factory_respects_explicit_max_steps(self) -> None:
+        adapter = make_gymnax_env("CartPole-v1", max_steps=200)
+        assert adapter._max_steps == 200
+        gp = adapter._gymnax_params(None)
+        assert gp.max_steps_in_episode == 201
+
+    def test_factory_adapter_runs_a_step(self) -> None:
+        adapter = make_gymnax_env("CartPole-v1", max_steps=5)
+        key = jax.random.key(42)
+        reset = adapter.reset(key)
+        step = adapter.step(key, reset.state, jnp.array(0))
+
+        assert step.observation.shape == (4,)
+        assert step.reward.shape == ()
+        assert not bool(step.truncated)
+        assert not bool(step.terminated)


### PR DESCRIPTION
## Summary

- Adds `GymnaxEnvAdapter` in `libs/rl-components/src/rl_components/gymnax_adapter.py` that wraps any native gymnax `Environment` into `EnvProtocol` with correct separated `terminated`/`truncated` signals
- Adds `make_gymnax_env(env_name, max_steps=None)` factory
- 13 new small tests covering all signal/auto-reset/spec/factory cases

## Problem

Gymnax's `is_terminal()` conflates true env termination with time-limit truncation into a single `done` signal (old OpenAI gym convention). This biases return estimates because the value bootstrap at truncation should not zero out the way a true terminal would.

## Approach

Set gymnax's `max_steps_in_episode = T + 1` so its own time-limit check can never fire at step T. Call `step_env()`/`reset_env()` directly (bypassing gymnax's JIT-wrapped `step()` and its built-in auto-reset). Check `state.time >= T` ourselves for `truncated`; the gymnax `done` signal then carries only true `terminated`.

## Test plan

- [ ] `pytest tests/small/test_rl_components_gymnax_adapter.py` — 13 tests pass
- [ ] `pytest tests/small/` — no regressions in existing gymnax bridge tests
- [ ] CI small/medium jobs green

## Follow-up

Update examples (`train_dqn.py`, `train_gac.py`, etc.) to use `make_gymnax_env() → make_gymnax_compat_env()` instead of raw gymnax envs — tracked separately.

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)